### PR TITLE
bootstrap-admin, change password, fix prod bind-mount perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,15 +35,20 @@ COPY --chown=app:app scripts ./scripts
 COPY --chown=app:app docker-entrypoint.sh ./docker-entrypoint.sh
 
 # Runtime data dirs (sqlite file, uploads, sessions). These are also exposed
-# as volumes in compose.yml so they survive container recreation.
+# as volumes in compose.yml so they survive container recreation. The entrypoint
+# re-chowns these at boot in case they are bind-mounted from a host dir owned
+# by a different uid.
 RUN install -d -o app -g app -m 0755 /app/db /app/tmp /app/tmp/uploads /app/tmp/sessions && \
     chmod +x /app/docker-entrypoint.sh
 
 ENV DATABASE_URL=/app/db/stickertrade.sqlite \
     PORT=44100 \
-    NODE_ENV=production
+    NODE_ENV=production \
+    APP_UID=1001 \
+    APP_GID=1001
 
-USER app
+# Start as root so the entrypoint can fix bind-mount ownership, then runuser
+# drops to the unprivileged `app` user before exec'ing the server.
 EXPOSE 44100
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Seeded credentials:
 | `npm start`         | Production-style boot                              |
 | `npm run migrate`   | Apply `migrations/*` SQL migrations                |
 | `npm run seed`      | Seed admin + sample user / sticker / invitation    |
+| `npm run bootstrap-admin` | Interactively create a single admin user (prod) |
 | `npm test`          | Run `node --test` smoke suite                      |
 | `npm run typecheck` | `tsc --noEmit`                                     |
 
@@ -57,5 +58,21 @@ Seeded credentials:
 | `DATABASE_URL`    | `./db/stickertrade.sqlite`       | Path to SQLite file                         |
 | `PORT`            | `44100`                          | HTTP listen port                            |
 | `NODE_ENV`        | `development`                    | Toggles dev logger, cookie secure flag, etc |
+
+## Production bootstrap
+
+The production container only runs migrations on boot — it does not seed any
+users. Use `npm run bootstrap-admin` to interactively create your first admin:
+
+```sh
+docker compose exec stickertrade npm run bootstrap-admin
+# Username: <your handle>
+# Password: <hidden>
+# Confirm password: <hidden>
+```
+
+The script refuses to create a duplicate username and never logs the password
+to the terminal. After that, log in, and invite anyone else via the
+`/invitations` page.
 
 See [`AGENTS.md`](./AGENTS.md) for architecture and conventions.

--- a/app/actions/change-password-page.tsx
+++ b/app/actions/change-password-page.tsx
@@ -1,0 +1,45 @@
+import { css } from 'remix/ui'
+
+import { routes } from '../routes.ts'
+import { Document } from '../ui/document.tsx'
+import { SubmitButton, TextField, errorStyle, flashStyle } from '../ui/form.tsx'
+import type { HeaderUser } from '../ui/header.tsx'
+
+export interface ChangePasswordPageProps {
+  user: HeaderUser
+  errors?: Record<string, string>
+  flash?: string
+}
+
+export function ChangePasswordPage() {
+  return ({ user, errors = {}, flash }: ChangePasswordPageProps) => (
+    <Document title="stickertrade - change password" user={user}>
+      <main mix={css({ maxWidth: '24rem', margin: '0 auto' })}>
+        <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>change password</h1>
+        {flash ? <p mix={flashStyle}>{flash}</p> : null}
+        <form method="post" action={routes.changePassword.action.href()}>
+          <TextField
+            name="currentPassword"
+            label="current password"
+            type="password"
+            error={errors.currentPassword}
+          />
+          <TextField
+            name="newPassword"
+            label="new password"
+            type="password"
+            error={errors.newPassword}
+          />
+          <TextField
+            name="confirmPassword"
+            label="confirm new password"
+            type="password"
+            error={errors.confirmPassword}
+          />
+          {errors._form ? <p mix={errorStyle}>{errors._form}</p> : null}
+          <SubmitButton label="change password" />
+        </form>
+      </main>
+    </Document>
+  )
+}

--- a/app/actions/change-password/controller.tsx
+++ b/app/actions/change-password/controller.tsx
@@ -1,0 +1,72 @@
+import { Database } from 'remix/data-table'
+import { Session } from 'remix/session'
+import { redirect } from 'remix/response/redirect'
+import { createController } from 'remix/router'
+
+import { hashPassword, verifyPassword } from '../../data/auth.ts'
+import { getCurrentUser } from '../../data/current-user.ts'
+import { users } from '../../data/schema.ts'
+import { routes } from '../../routes.ts'
+import { ChangePasswordPage } from '../change-password-page.tsx'
+
+export default createController(routes.changePassword, {
+  actions: {
+    index(context) {
+      const user = getCurrentUser(context)
+      if (!user) return redirect(routes.login.index.href(), 303)
+      const session = context.get(Session)
+      const flash = session.get('password_flash') as string | undefined
+      session.unset('password_flash')
+      return context.render(<ChangePasswordPage user={user} flash={flash} />)
+    },
+
+    async action(context) {
+      const user = getCurrentUser(context)
+      if (!user) return redirect(routes.login.index.href(), 303)
+
+      const formData = context.get(FormData)
+      const currentPassword = String(formData.get('currentPassword') ?? '')
+      const newPassword = String(formData.get('newPassword') ?? '')
+      const confirmPassword = String(formData.get('confirmPassword') ?? '')
+
+      const errors: Record<string, string> = {}
+      if (newPassword.length < 8 || newPassword.length > 64) {
+        errors.newPassword = 'New password must be 8-64 characters'
+      }
+      if (newPassword !== confirmPassword) {
+        errors.confirmPassword = "Passwords don't match"
+      }
+      if (currentPassword === newPassword && !errors.newPassword) {
+        errors.newPassword = 'New password must be different from current password'
+      }
+
+      const db = context.get(Database)
+
+      if (Object.keys(errors).length === 0) {
+        const row = await db.findOne(users, { where: { id: user.id } })
+        if (!row || !(await verifyPassword(currentPassword, row.password_hash))) {
+          errors.currentPassword = 'Current password is incorrect'
+        }
+      }
+
+      if (Object.keys(errors).length > 0) {
+        return context.render(<ChangePasswordPage user={user} errors={errors} />, {
+          status: 400,
+        })
+      }
+
+      await db.update(users, user.id, {
+        password_hash: await hashPassword(newPassword),
+        updated_at: Date.now(),
+      })
+
+      // Rotate the session ID after a credential change so any stolen
+      // session cookie is invalidated.
+      const session = context.get(Session)
+      session.regenerateId(true)
+      session.flash('password_flash', 'Password updated.')
+
+      return redirect(routes.changePassword.index.href(), 303)
+    },
+  },
+})

--- a/app/router.ts
+++ b/app/router.ts
@@ -6,6 +6,7 @@ import { staticFiles } from 'remix/middleware/static'
 
 import rootController from './actions/controller.tsx'
 import adminController from './actions/admin/controller.tsx'
+import changePasswordController from './actions/change-password/controller.tsx'
 import invitationsController from './actions/invitations/controller.tsx'
 import invitationController from './actions/invitation/controller.tsx'
 import loginController from './actions/login/controller.tsx'
@@ -44,5 +45,6 @@ router.map(routes.admin, adminController)
 router.map(routes.invitations, invitationsController)
 router.map(routes.invitation, invitationController)
 router.map(routes.login, loginController)
+router.map(routes.changePassword, changePasswordController)
 router.map(routes.removeSticker, removeStickerController)
 router.map(routes.uploadSticker, uploadStickerController)

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -26,6 +26,7 @@ export const routes = route({
   // Auth
   login: form('/login'),
   logout: post('/logout'),
+  changePassword: form('/account/password'),
 
   // Invitations
   invitations: route('/invitations', {

--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -46,6 +46,9 @@ function UserMenu(handle: Handle<{ user: HeaderUser }>) {
         <a href={routes.invitations.index.href()} mix={menuLinkStyle}>
           invitations
         </a>
+        <a href={routes.changePassword.index.href()} mix={menuLinkStyle}>
+          password
+        </a>
         {user.role === 'ADMIN' ? (
           <a href={routes.admin.users.href()} mix={menuLinkStyle}>
             admin

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+# We start as root so bind-mounted volume dirs can be chowned to the app user
+# even when they come up owned by root (the default for compose bind mounts).
+# After fixing ownership we drop to the `app` user via runuser.
+if [ "$(id -u)" = "0" ]; then
+  chown -R "${APP_UID:-1001}:${APP_GID:-1001}" /app/db /app/tmp /app/tmp/uploads /app/tmp/sessions
+  exec runuser -u app -- "$0" "$@"
+fi
+
 # Apply any pending SQL migrations before the server boots. Idempotent —
 # already-applied migrations are skipped via the journal table.
 echo "[stickertrade] running migrations..."

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "NODE_ENV=test node --env-file-if-exists=.env.test --import remix/node-tsx --test 'test/**/*.test.ts' 'test/**/*.test.tsx'",
     "typecheck": "tsc --noEmit",
     "migrate": "node --env-file-if-exists=.env --import remix/node-tsx scripts/migrate.ts",
-    "seed": "node --env-file-if-exists=.env --import remix/node-tsx scripts/seed.ts"
+    "seed": "node --env-file-if-exists=.env --import remix/node-tsx scripts/seed.ts",
+    "bootstrap-admin": "node --env-file-if-exists=.env --import remix/node-tsx scripts/bootstrap-admin.ts"
   },
   "engines": {
     "node": ">=24.3.0"

--- a/scripts/bootstrap-admin.ts
+++ b/scripts/bootstrap-admin.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'node:crypto'
+import { createInterface, type Interface } from 'node:readline/promises'
+
+import bcrypt from 'bcryptjs'
+
+import { db } from '../app/data/db.ts'
+import { config, users, UserRoles } from '../app/data/schema.ts'
+
+interface MutableInterface extends Interface {
+  _writeToOutput?: (stringToWrite: string) => void
+}
+
+async function askVisible(rl: Interface, prompt: string): Promise<string> {
+  return (await rl.question(prompt)).trim()
+}
+
+async function askHidden(rl: MutableInterface, prompt: string): Promise<string> {
+  process.stdout.write(prompt)
+  const originalWrite = rl._writeToOutput
+  rl._writeToOutput = (stringToWrite: string) => {
+    // Allow newlines through (so the user sees they hit enter); swallow keystroke echoes.
+    if (stringToWrite === '\n' || stringToWrite === '\r\n' || stringToWrite === '\r') {
+      originalWrite?.call(rl, stringToWrite)
+    }
+  }
+  try {
+    const value = await rl.question('')
+    return value
+  } finally {
+    rl._writeToOutput = originalWrite
+  }
+}
+
+function validateUsername(value: string): string | null {
+  if (value.length < 3 || value.length > 16) return 'Username must be 3-16 characters'
+  if (!/^[a-zA-Z0-9_-]+$/.test(value))
+    return 'Username may only contain letters, numbers, underscores, and dashes'
+  return null
+}
+
+function validatePassword(value: string): string | null {
+  if (value.length < 8) return 'Password must be at least 8 characters'
+  if (value.length > 64) return 'Password must be 64 characters or fewer'
+  return null
+}
+
+async function ensureConfigRow(): Promise<void> {
+  const existing = await db.findOne(config, { where: { id: 1 } })
+  if (existing) return
+  await db.create(config, { id: 1, invitations_enabled: true })
+}
+
+async function main() {
+  const rl: MutableInterface = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+  })
+
+  try {
+    console.log('Bootstrap a stickertrade admin user.')
+    console.log('')
+
+    let username: string
+    while (true) {
+      username = await askVisible(rl, 'Username: ')
+      const err = validateUsername(username)
+      if (err) {
+        console.log(`  ✗ ${err}`)
+        continue
+      }
+      const existing = await db.findOne(users, { where: { username } })
+      if (existing) {
+        console.log(`  ✗ User "${username}" already exists. Choose a different username.`)
+        continue
+      }
+      break
+    }
+
+    let password: string
+    while (true) {
+      const first = await askHidden(rl, 'Password: ')
+      const err = validatePassword(first)
+      if (err) {
+        console.log(`  ✗ ${err}`)
+        continue
+      }
+      const second = await askHidden(rl, 'Confirm password: ')
+      if (first !== second) {
+        console.log("  ✗ Passwords don't match. Try again.")
+        continue
+      }
+      password = first
+      break
+    }
+
+    await ensureConfigRow()
+
+    const now = Date.now()
+    await db.create(users, {
+      id: randomUUID(),
+      username,
+      role: UserRoles.Admin,
+      password_hash: await bcrypt.hash(password, 10),
+      invitation_limit: 100,
+      created_at: now,
+      updated_at: now,
+    })
+
+    console.log('')
+    console.log(`✓ Admin user "${username}" created.`)
+  } finally {
+    rl.close()
+  }
+}
+
+await main()

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,6 +18,7 @@ import { createRouter, type MiddlewareContext } from 'remix/router'
 
 import rootController from '../app/actions/controller.tsx'
 import adminController from '../app/actions/admin/controller.tsx'
+import changePasswordController from '../app/actions/change-password/controller.tsx'
 import invitationsController from '../app/actions/invitations/controller.tsx'
 import invitationController from '../app/actions/invitation/controller.tsx'
 import loginController from '../app/actions/login/controller.tsx'
@@ -104,6 +105,7 @@ export async function createTestEnv(): Promise<TestEnv> {
   router.map(routes.invitations, invitationsController as any)
   router.map(routes.invitation, invitationController as any)
   router.map(routes.login, loginController as any)
+  router.map(routes.changePassword, changePasswordController as any)
   router.map(routes.removeSticker, removeStickerController as any)
   router.map(routes.uploadSticker, uploadStickerController as any)
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -206,6 +206,69 @@ describe('admin', () => {
   })
 })
 
+describe('change password', () => {
+  it('rejects wrong current password', async () => {
+    const env = await createTestEnv()
+    try {
+      await seedUser(env, 'carol', 'currentpass')
+      const cookie = await loginAs(env, 'carol', 'currentpass')
+
+      const body = new FormData()
+      body.set('currentPassword', 'wrongpass')
+      body.set('newPassword', 'newpassword123')
+      body.set('confirmPassword', 'newpassword123')
+      const res = await env.fetch(
+        new Request(buildUrl(routes.changePassword.action.href()), {
+          method: 'POST',
+          headers: { cookie },
+          body,
+        }),
+      )
+      assert.equal(res.status, 400)
+      assert.match(await res.text(), /Current password is incorrect/)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('updates password and lets the user log in with the new one', async () => {
+    const env = await createTestEnv()
+    try {
+      await seedUser(env, 'dan', 'oldpass1')
+      const cookie = await loginAs(env, 'dan', 'oldpass1')
+
+      const body = new FormData()
+      body.set('currentPassword', 'oldpass1')
+      body.set('newPassword', 'brand_new_pw')
+      body.set('confirmPassword', 'brand_new_pw')
+      const res = await env.fetch(
+        new Request(buildUrl(routes.changePassword.action.href()), {
+          method: 'POST',
+          headers: { cookie },
+          body,
+        }),
+      )
+      assert.equal(res.status, 303)
+      assert.equal(res.headers.get('location'), routes.changePassword.index.href())
+
+      // Old password should no longer work
+      const oldBody = new FormData()
+      oldBody.set('username', 'dan')
+      oldBody.set('password', 'oldpass1')
+      const oldLogin = await env.fetch(
+        new Request(buildUrl(routes.login.action.href()), { method: 'POST', body: oldBody }),
+      )
+      assert.equal(oldLogin.status, 400)
+
+      // New password works
+      const newCookie = await loginAs(env, 'dan', 'brand_new_pw')
+      assert.ok(newCookie)
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
 describe('dev logs', () => {
   it('renders the dev logs index', async () => {
     const env = await createTestEnv()


### PR DESCRIPTION
Three things stacked on the v3 port:

- `scripts/bootstrap-admin.ts`: interactive CLI that prompts for username + password (hidden, with confirm), refuses duplicates, hashes with bcrypt, creates one admin row. For prod first-boot via `docker compose exec stickertrade npm run bootstrap-admin`.
- `/account/password`: in-app change-password page reachable from the header. Requires current password, regenerates the session id on success.
- Fix prod boot: bind-mounted volume dirs come up owned by root, so opening the sqlite file failed when the container started as the unprivileged `app` user. Container now starts as root, the entrypoint chowns the data mounts, then re-execs as `app` via `runuser`.

Verified locally: typecheck clean, 12/12 tests pass, docker build + run with empty bind mounts boots cleanly (migrations + server), restart picks up existing data.