### PR TITLE
json api with bearer-token auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,16 @@ request, components are not React.
 - `app/router.ts` — composes the middleware stack and maps each route map to a controller
 - `app/actions/controller.tsx` — root controller for top-level leaf routes
 - `app/actions/<route-key>/controller.tsx` — one controller per nested route map (`admin`,
-  `invitations`, `invitation`, `login`, `upload-sticker`, `remove-sticker`)
+  `invitations`, `invitation`, `login`, `upload-sticker`, `remove-sticker`, `edit-profile`,
+  `edit-sticker`, `change-password`, `api`)
 - `app/actions/*-page.tsx` — page components, returned via `context.render(...)`
+- `app/actions/api/` — JSON API (controller, serializers, `jsonOk`/`jsonError` helpers)
 - `app/ui/` — shared UI primitives (`document.tsx`, `header.tsx`, `footer.tsx`,
   `sticker-card.tsx`, `user-card.tsx`, `form.tsx`, `theme.ts`)
-- `app/data/` — schema, db wiring, auth, dev-logs loader, roadmap, upload pipeline
-- `app/middleware/` — `database.ts` and `render.tsx`
+- `app/data/` — schema, db wiring, auth, dev-logs loader, roadmap, upload pipeline,
+  api-tokens helper
+- `app/middleware/` — `database.ts`, `render.tsx`, `csrf-or-bearer.ts` (skips CSRF
+  for `/api/*` and bearer-authenticated requests)
 - `app/utils/time.ts` — small relative-time formatter
 - `migrations/<timestamp>_<slug>/{up,down}.sql` — SQL migrations
 - `scripts/migrate.ts`, `scripts/seed.ts` — one-shot operational scripts

--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ The script refuses to create a duplicate username. The password is passed on
 the command line, so consider prefixing the command with a space (with
 `HISTCONTROL=ignorespace` set) or running `history -d $(history 1)` afterward
 to keep it out of shell history. Once you're logged in, you can change it via
-the in-app `/account/password` page.
+the in-app `/account/profile` page.
+
+## JSON API
+
+A small REST API lives at `/api/*`. Reads are public; writes require a bearer
+token. Create one at `/account/profile` → "api tokens" — the plaintext is shown
+exactly once.
+
+| Method | Path                                  | Auth     | Body                                  |
+| ------ | ------------------------------------- | -------- | ------------------------------------- |
+| GET    | `/api/stickers`                       | optional | —                                     |
+| GET    | `/api/stickers/:id`                   | optional | —                                     |
+| POST   | `/api/stickers`                       | required | `multipart/form-data` (`name`, `image`) |
+| PATCH  | `/api/stickers/:id`                   | required | `application/json` `{ "name": "..." }` |
+| DELETE | `/api/stickers/:id`                   | required | —                                     |
+| GET    | `/api/me`                             | required | —                                     |
+| GET    | `/api/users/:username`                | optional | —                                     |
+| GET    | `/api/users/:username/stickers`       | optional | —                                     |
+
+Auth header: `Authorization: Bearer st_…`. Errors come back as
+`{ "error": "..." }` with the appropriate HTTP status; validation failures
+include an `issues` array.
+
+Each token inherits the permissions of the user that created it (no scopes).
+Admins' tokens can edit/delete any sticker, just like in the web UI.
 
 See [`AGENTS.md`](./AGENTS.md) for architecture and conventions.

--- a/app/actions/api/controller.tsx
+++ b/app/actions/api/controller.tsx
@@ -1,0 +1,210 @@
+import { randomUUID } from 'node:crypto'
+
+import { Database } from 'remix/data-table'
+import { inList } from 'remix/data-table/operators'
+import { createController } from 'remix/router'
+
+import { getCurrentUser } from '../../data/current-user.ts'
+import { stickers, users } from '../../data/schema.ts'
+import { processStickerUpload } from '../../data/upload-image.ts'
+import { uploadStorage } from '../../data/uploads.ts'
+import { routes } from '../../routes.ts'
+import { jsonError, jsonOk } from './json.ts'
+import { serializeSticker, serializeUser, serializeUserStub } from './serializers.ts'
+
+const PAGE_SIZE = 50
+
+function readPage(url: URL): number {
+  const raw = url.searchParams.get('page') ?? '0'
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+async function safeRemoveStoredUpload(url: string | null | undefined) {
+  if (!url || !url.startsWith('/uploads/')) return
+  const key = url.slice('/uploads/'.length)
+  try {
+    await uploadStorage.remove(key)
+  } catch {
+    // ignore
+  }
+}
+
+export default createController(routes.api, {
+  actions: {
+    // -------- /api/me --------
+    me(context) {
+      const user = getCurrentUser(context)
+      if (!user) return jsonError(401, 'Unauthorized')
+      // getCurrentUser returns AuthedUser which already includes the fields we need.
+      return jsonOk({ user: serializeUser(user as never) })
+    },
+
+    // -------- GET /api/stickers --------
+    async stickersIndex(context) {
+      const db = context.get(Database)
+      const page = readPage(context.url)
+      const rows = await db.findMany(stickers, {
+        orderBy: ['created_at', 'desc'],
+        limit: PAGE_SIZE + 1,
+        offset: page * PAGE_SIZE,
+      })
+      const hasMore = rows.length > PAGE_SIZE
+      const slice = rows.slice(0, PAGE_SIZE)
+      const ownerIds = Array.from(
+        new Set(slice.map((s) => s.owner_id).filter((id): id is string => !!id)),
+      )
+      const ownerRows = ownerIds.length
+        ? await db.findMany(users, { where: inList('id', ownerIds) })
+        : []
+      const ownerById = new Map(ownerRows.map((u) => [u.id, u]))
+      return jsonOk({
+        stickers: slice.map((s) => {
+          const owner = s.owner_id ? ownerById.get(s.owner_id) ?? null : null
+          return serializeSticker(s, owner)
+        }),
+        page,
+        has_more: hasMore,
+      })
+    },
+
+    // -------- GET /api/stickers/:id --------
+    async stickerShow(context) {
+      const db = context.get(Database)
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return jsonError(404, 'Not Found')
+      let owner = null
+      if (sticker.owner_id) {
+        owner = (await db.findOne(users, { where: { id: sticker.owner_id } })) ?? null
+      }
+      return jsonOk({ sticker: serializeSticker(sticker, owner) })
+    },
+
+    // -------- POST /api/stickers --------
+    async stickerCreate(context) {
+      const user = getCurrentUser(context)
+      if (!user) return jsonError(401, 'Unauthorized')
+
+      const formData = context.get(FormData)
+      const name = String(formData.get('name') ?? '').trim()
+      const file = formData.get('image')
+
+      const issues: Array<{ path: string[]; message: string }> = []
+      if (name.length === 0 || name.length > 60) {
+        issues.push({ path: ['name'], message: 'Name must be 1-60 characters' })
+      }
+      if (!(file instanceof File) || file.size === 0) {
+        issues.push({ path: ['image'], message: 'Please attach an image' })
+      }
+      if (issues.length > 0) return jsonError(400, 'Validation failed', issues)
+
+      let storedImageUrl: string
+      try {
+        storedImageUrl = await processStickerUpload(file as File)
+      } catch (error) {
+        return jsonError(400, error instanceof Error ? error.message : 'Upload failed')
+      }
+
+      const db = context.get(Database)
+      const now = Date.now()
+      const id = randomUUID()
+      await db.create(stickers, {
+        id,
+        name,
+        image_url: storedImageUrl,
+        owner_id: user.id,
+        created_at: now,
+        updated_at: now,
+      })
+      const created = await db.findOne(stickers, { where: { id } })
+      return jsonOk({ sticker: serializeSticker(created!, user as never) }, { status: 201 })
+    },
+
+    // -------- PATCH /api/stickers/:id --------
+    async stickerUpdate(context) {
+      const user = getCurrentUser(context)
+      if (!user) return jsonError(401, 'Unauthorized')
+
+      const db = context.get(Database)
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return jsonError(404, 'Not Found')
+      if (sticker.owner_id !== user.id && user.role !== 'ADMIN') {
+        return jsonError(403, 'Forbidden')
+      }
+
+      // Accept either JSON ({"name": "..."}) or form-encoded body.
+      let payload: { name?: unknown }
+      const contentType = context.request.headers.get('content-type') ?? ''
+      if (contentType.includes('application/json')) {
+        try {
+          payload = (await context.request.json()) as { name?: unknown }
+        } catch {
+          return jsonError(400, 'Invalid JSON body')
+        }
+      } else {
+        const formData = context.get(FormData)
+        payload = { name: formData.get('name') }
+      }
+
+      const name = typeof payload.name === 'string' ? payload.name.trim() : ''
+      if (name.length === 0 || name.length > 60) {
+        return jsonError(400, 'Validation failed', [
+          { path: ['name'], message: 'Name must be 1-60 characters' },
+        ])
+      }
+
+      await db.update(stickers, sticker.id, { name, updated_at: Date.now() })
+      const updated = await db.findOne(stickers, { where: { id: sticker.id } })
+      let owner = null
+      if (updated?.owner_id) {
+        owner = (await db.findOne(users, { where: { id: updated.owner_id } })) ?? null
+      }
+      return jsonOk({ sticker: serializeSticker(updated!, owner) })
+    },
+
+    // -------- DELETE /api/stickers/:id --------
+    async stickerDestroy(context) {
+      const user = getCurrentUser(context)
+      if (!user) return jsonError(401, 'Unauthorized')
+
+      const db = context.get(Database)
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return jsonError(404, 'Not Found')
+      if (sticker.owner_id !== user.id && user.role !== 'ADMIN') {
+        return jsonError(403, 'Forbidden')
+      }
+      await db.delete(stickers, sticker.id)
+      await safeRemoveStoredUpload(sticker.image_url)
+      return new Response(null, { status: 204 })
+    },
+
+    // -------- GET /api/users/:username --------
+    async userShow(context) {
+      const db = context.get(Database)
+      const u = await db.findOne(users, { where: { username: context.params.username } })
+      if (!u) return jsonError(404, 'Not Found')
+      return jsonOk({
+        user: {
+          username: u.username,
+          avatar_url: u.avatar_url ?? null,
+          created_at: u.created_at,
+        },
+      })
+    },
+
+    // -------- GET /api/users/:username/stickers --------
+    async userStickers(context) {
+      const db = context.get(Database)
+      const u = await db.findOne(users, { where: { username: context.params.username } })
+      if (!u) return jsonError(404, 'Not Found')
+      const rows = await db.findMany(stickers, {
+        where: { owner_id: u.id },
+        orderBy: ['created_at', 'desc'],
+      })
+      return jsonOk({
+        user: serializeUserStub(u),
+        stickers: rows.map((s) => serializeSticker(s, u)),
+      })
+    },
+  },
+})

--- a/app/actions/api/json.ts
+++ b/app/actions/api/json.ts
@@ -1,0 +1,29 @@
+/**
+ * JSON response helpers for the /api/* surface.
+ *
+ * Keeps response construction terse and consistent across controllers:
+ *   return jsonOk({ sticker: ... })
+ *   return jsonError(404, 'Not Found')
+ */
+
+export interface ApiErrorBody {
+  error: string
+  issues?: unknown
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' }
+
+export function jsonOk(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { ...JSON_HEADERS, ...(init.headers ?? {}) },
+  })
+}
+
+export function jsonError(status: number, error: string, issues?: unknown): Response {
+  const body: ApiErrorBody = issues ? { error, issues } : { error }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  })
+}

--- a/app/actions/api/serializers.ts
+++ b/app/actions/api/serializers.ts
@@ -1,0 +1,49 @@
+import type { Sticker, User } from '../../data/schema.ts'
+
+export interface JsonSticker {
+  id: string
+  name: string
+  image_url: string
+  owner: JsonUserStub | null
+  created_at: number
+  updated_at: number
+}
+
+export interface JsonUserStub {
+  username: string
+  avatar_url: string | null
+}
+
+export interface JsonUser extends JsonUserStub {
+  id: string
+  role: string
+  created_at: number
+}
+
+export function serializeUserStub(user: Pick<User, 'username' | 'avatar_url'>): JsonUserStub {
+  return { username: user.username, avatar_url: user.avatar_url ?? null }
+}
+
+export function serializeUser(user: User): JsonUser {
+  return {
+    id: user.id,
+    username: user.username,
+    role: user.role,
+    avatar_url: user.avatar_url ?? null,
+    created_at: user.created_at,
+  }
+}
+
+export function serializeSticker(
+  sticker: Sticker,
+  owner: Pick<User, 'username' | 'avatar_url'> | null,
+): JsonSticker {
+  return {
+    id: sticker.id,
+    name: sticker.name,
+    image_url: sticker.image_url,
+    owner: owner ? serializeUserStub(owner) : null,
+    created_at: sticker.created_at,
+    updated_at: sticker.updated_at,
+  }
+}

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -5,11 +5,12 @@ import { redirect } from 'remix/response/redirect'
 import { createController } from 'remix/router'
 
 import { assetServer } from '../assets.ts'
+import { createTokenForUser } from '../data/api-tokens.ts'
 import { getCurrentUser } from '../data/current-user.ts'
 import { buildDevLogsFeed } from '../data/dev-logs-feed.ts'
 import { getDevLog, getDevLogs } from '../data/dev-logs.ts'
 import { roadmapTasks } from '../data/roadmap.ts'
-import { stickers, users } from '../data/schema.ts'
+import { apiTokens, stickers, users } from '../data/schema.ts'
 import { uploadStorage } from '../data/uploads.ts'
 import { routes } from '../routes.ts'
 import { BrandPage } from './brand-page.tsx'
@@ -197,6 +198,41 @@ export default createController(routes, {
       session.unset('auth')
       session.regenerateId(true)
       return redirect(routes.home.href(), 303)
+    },
+
+    // -------- API token management (HTML forms, not API endpoints) --------
+    async createApiToken(context) {
+      const user = getCurrentUser(context)
+      if (!user) return redirect(routes.login.index.href(), 303)
+      const formData = context.get(FormData)
+      const name = String(formData.get('name') ?? '').trim()
+      const session = context.get(Session)
+      if (name.length === 0 || name.length > 60) {
+        session.flash('token_error_name', 'Token name must be 1-60 characters')
+        return redirect(routes.editProfile.index.href(), 303)
+      }
+      const db = context.get(Database)
+      const created = await createTokenForUser(db, user, name)
+      session.flash(
+        'token_new',
+        JSON.stringify({ name: created.name, plaintext: created.plaintext }),
+      )
+      return redirect(routes.editProfile.index.href(), 303)
+    },
+
+    async revokeApiToken(context) {
+      const user = getCurrentUser(context)
+      if (!user) return redirect(routes.login.index.href(), 303)
+      const db = context.get(Database)
+      const row = await db.findOne(apiTokens, { where: { id: context.params.id } })
+      if (!row || row.user_id !== user.id) {
+        // Don't leak whether the id exists.
+        return redirect(routes.editProfile.index.href(), 303)
+      }
+      await db.delete(apiTokens, row.id)
+      const session = context.get(Session)
+      session.flash('token_flash', `Token "${row.name}" revoked.`)
+      return redirect(routes.editProfile.index.href(), 303)
     },
 
     // -------- Dev logs --------

--- a/app/actions/edit-profile-page.tsx
+++ b/app/actions/edit-profile-page.tsx
@@ -13,6 +13,14 @@ import {
 import type { HeaderUser } from '../ui/header.tsx'
 import { colors } from '../ui/theme.ts'
 
+export interface TokenRow {
+  id: string
+  name: string
+  prefix: string
+  created_at: number
+  last_used_at: number | null
+}
+
 export interface EditProfilePageProps {
   user: HeaderUser
   /** Errors and flash for the avatar form. */
@@ -21,6 +29,12 @@ export interface EditProfilePageProps {
   /** Errors and flash for the password form. */
   passwordErrors?: Record<string, string>
   passwordFlash?: string
+  /** API tokens for the current user. */
+  tokens?: TokenRow[]
+  tokenErrors?: Record<string, string>
+  tokenFlash?: string
+  /** Plaintext value of a freshly-created token, shown exactly once. */
+  newToken?: { name: string; plaintext: string }
 }
 
 export function EditProfilePage() {
@@ -30,6 +44,10 @@ export function EditProfilePage() {
     avatarFlash,
     passwordErrors = {},
     passwordFlash,
+    tokens = [],
+    tokenErrors = {},
+    tokenFlash,
+    newToken,
   }: EditProfilePageProps) => (
     <Document title="stickertrade - edit profile" user={user}>
       <main mix={css({ maxWidth: '28rem', margin: '0 auto' })}>
@@ -107,6 +125,64 @@ export function EditProfilePage() {
             <SubmitButton label="change password" />
           </form>
         </section>
+
+        <section mix={sectionStyle}>
+          <h2 mix={sectionHeadingStyle}>api tokens</h2>
+          {tokenFlash ? <p mix={flashStyle}>{tokenFlash}</p> : null}
+          {newToken ? (
+            <div mix={newTokenBoxStyle}>
+              <p mix={css({ marginBottom: '0.5rem', fontWeight: 600 })}>
+                token "{newToken.name}" created
+              </p>
+              <p mix={css({ marginBottom: '0.5rem', fontSize: '0.85rem' })}>
+                copy this value now — you won't be able to see it again.
+              </p>
+              <code mix={newTokenValueStyle}>{newToken.plaintext}</code>
+            </div>
+          ) : null}
+
+          <p mix={helpTextStyle}>
+            tokens authenticate API requests via{' '}
+            <code>Authorization: Bearer &lt;token&gt;</code>. each token has the same
+            permissions as your account.
+          </p>
+
+          {tokens.length === 0 ? (
+            <p mix={css({ fontStyle: 'italic', opacity: 0.7, marginBottom: '0.75rem' })}>
+              no tokens yet.
+            </p>
+          ) : (
+            <ul mix={tokenListStyle}>
+              {tokens.map((tok) => (
+                <li key={tok.id} mix={tokenRowStyle}>
+                  <div>
+                    <p mix={css({ fontWeight: 600 })}>{tok.name}</p>
+                    <p mix={css({ fontSize: '0.8rem', opacity: 0.7 })}>
+                      <code>{tok.prefix}…</code> · created{' '}
+                      {new Date(tok.created_at).toISOString().slice(0, 10)}
+                      {tok.last_used_at
+                        ? ` · last used ${new Date(tok.last_used_at).toISOString().slice(0, 10)}`
+                        : ' · never used'}
+                    </p>
+                  </div>
+                  <form method="post" action={routes.revokeApiToken.href({ id: tok.id })}>
+                    <CsrfField />
+                    <button type="submit" mix={removeBtnStyle}>
+                      revoke
+                    </button>
+                  </form>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <form method="post" action={routes.createApiToken.href()}>
+            <CsrfField />
+            <TextField name="name" label="token name (e.g. 'my laptop')" error={tokenErrors.name} />
+            {tokenErrors._form ? <p mix={errorStyle}>{tokenErrors._form}</p> : null}
+            <SubmitButton label="create token" />
+          </form>
+        </section>
       </main>
     </Document>
   )
@@ -148,4 +224,39 @@ const removeBtnStyle = css({
   font: 'inherit',
   fontSize: '0.85rem',
   '&:hover': { background: colors.primary[500], color: colors.dark[500] },
+})
+
+const tokenListStyle = css({
+  listStyle: 'none',
+  margin: '0 0 1rem',
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+})
+
+const tokenRowStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '0.5rem 0.75rem',
+  border: `1px solid ${colors.light[500]}33`,
+  gap: '0.5rem',
+})
+
+const newTokenBoxStyle = css({
+  marginBottom: '1rem',
+  padding: '0.75rem',
+  background: '#0e0709',
+  border: `1px solid ${colors.primary[500]}`,
+})
+
+const newTokenValueStyle = css({
+  display: 'block',
+  padding: '0.5rem',
+  background: colors.dark[500],
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '0.85rem',
+  wordBreak: 'break-all',
+  color: colors.primary[400],
 })

--- a/app/actions/edit-profile/controller.tsx
+++ b/app/actions/edit-profile/controller.tsx
@@ -3,6 +3,7 @@ import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
 import { createController } from 'remix/router'
 
+import { listTokensForUser } from '../../data/api-tokens.ts'
 import { getCurrentUser } from '../../data/current-user.ts'
 import { users } from '../../data/schema.ts'
 import { processAvatarUpload } from '../../data/upload-image.ts'
@@ -22,7 +23,7 @@ async function safeRemoveStoredUpload(url: string | null) {
 
 export default createController(routes.editProfile, {
   actions: {
-    index(context) {
+    async index(context) {
       const user = getCurrentUser(context)
       if (!user) return redirect(routes.login.index.href(), 303)
       const session = context.get(Session)
@@ -30,8 +31,41 @@ export default createController(routes.editProfile, {
       session.unset('profile_flash')
       const passwordFlash = session.get('password_flash') as string | undefined
       session.unset('password_flash')
+      const tokenFlash = session.get('token_flash') as string | undefined
+      session.unset('token_flash')
+      const tokenErrorName = session.get('token_error_name') as string | undefined
+      session.unset('token_error_name')
+      const tokenNewRaw = session.get('token_new') as string | undefined
+      session.unset('token_new')
+
+      const db = context.get(Database)
+      const tokens = (await listTokensForUser(db, user.id)).map((t) => ({
+        id: t.id,
+        name: t.name,
+        prefix: t.prefix,
+        created_at: t.created_at,
+        last_used_at: t.last_used_at ?? null,
+      }))
+
+      let newToken: { name: string; plaintext: string } | undefined
+      if (tokenNewRaw) {
+        try {
+          newToken = JSON.parse(tokenNewRaw)
+        } catch {
+          // ignore malformed flash
+        }
+      }
+
       return context.render(
-        <EditProfilePage user={user} avatarFlash={avatarFlash} passwordFlash={passwordFlash} />,
+        <EditProfilePage
+          user={user}
+          avatarFlash={avatarFlash}
+          passwordFlash={passwordFlash}
+          tokens={tokens}
+          tokenFlash={tokenFlash}
+          tokenErrors={tokenErrorName ? { name: tokenErrorName } : undefined}
+          newToken={newToken}
+        />,
       )
     },
 

--- a/app/data/api-tokens.ts
+++ b/app/data/api-tokens.ts
@@ -1,0 +1,80 @@
+import { randomBytes, randomUUID } from 'node:crypto'
+
+import bcrypt from 'bcryptjs'
+import type { Database } from 'remix/data-table'
+
+import { apiTokens, type User } from './schema.ts'
+
+/**
+ * Tokens look like `st_<48 hex chars>`. The `st_` prefix lets a leaked token
+ * be recognised by automated secret scanners; the rest is high-entropy random.
+ */
+export const TOKEN_PREFIX = 'st_'
+export const TOKEN_BYTES = 24 // -> 48 hex chars
+export const PREFIX_LEN = 12 // first 12 chars of plaintext stored in the row for lookup
+
+export interface CreatedToken {
+  id: string
+  plaintext: string
+  prefix: string
+  name: string
+  created_at: number
+}
+
+/** Generate a fresh plaintext token. */
+export function newPlaintextToken(): string {
+  return TOKEN_PREFIX + randomBytes(TOKEN_BYTES).toString('hex')
+}
+
+/**
+ * Create a token row for a user. Returns the plaintext exactly once; the
+ * caller is responsible for showing it to the user and never persisting it.
+ */
+export async function createTokenForUser(
+  db: Database,
+  user: Pick<User, 'id'>,
+  name: string,
+): Promise<CreatedToken> {
+  const plaintext = newPlaintextToken()
+  const prefix = plaintext.slice(0, PREFIX_LEN)
+  const tokenHash = await bcrypt.hash(plaintext, 10)
+  const id = randomUUID()
+  const now = Date.now()
+  await db.create(apiTokens, {
+    id,
+    user_id: user.id,
+    name,
+    token_hash: tokenHash,
+    prefix,
+    created_at: now,
+  })
+  return { id, plaintext, prefix, name, created_at: now }
+}
+
+/**
+ * Verify a plaintext token. Returns the row on success, or null. Also touches
+ * `last_used_at` so the UI can show recency.
+ */
+export async function verifyToken(
+  db: Database,
+  plaintext: string,
+): Promise<{ user_id: string; token_id: string } | null> {
+  if (!plaintext.startsWith(TOKEN_PREFIX)) return null
+  const prefix = plaintext.slice(0, PREFIX_LEN)
+  const candidates = await db.findMany(apiTokens, { where: { prefix } })
+  for (const row of candidates) {
+    if (await bcrypt.compare(plaintext, row.token_hash)) {
+      // Best-effort touch — don't block verification on it.
+      void db.update(apiTokens, row.id, { last_used_at: Date.now() }).catch(() => {})
+      return { user_id: row.user_id, token_id: row.id }
+    }
+  }
+  return null
+}
+
+export async function listTokensForUser(db: Database, userId: string) {
+  return db.findMany(apiTokens, {
+    where: { user_id: userId },
+    orderBy: ['created_at', 'desc'],
+  })
+}

--- a/app/data/auth.ts
+++ b/app/data/auth.ts
@@ -1,10 +1,15 @@
 import bcrypt from 'bcryptjs'
 import { Database } from 'remix/data-table'
-import { auth, createSessionAuthScheme } from 'remix/middleware/auth'
+import {
+  auth,
+  createBearerTokenAuthScheme,
+  createSessionAuthScheme,
+} from 'remix/middleware/auth'
 import { createCookie } from 'remix/cookie'
 import { createFsSessionStorage } from 'remix/session-storage/fs'
 import { session } from 'remix/middleware/session'
 
+import { verifyToken } from './api-tokens.ts'
 import { users, type User } from './schema.ts'
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -47,6 +52,16 @@ export function loadAuth() {
         },
         invalidate(s) {
           s.unset('auth')
+        },
+      }),
+      createBearerTokenAuthScheme<User>({
+        async verify(token, context) {
+          const db = context.get(Database)
+          if (!db) return null
+          const match = await verifyToken(db, token)
+          if (!match) return null
+          const user = await db.findOne(users, { where: { id: match.user_id } })
+          return user ?? null
         },
       }),
     ],

--- a/app/data/schema.ts
+++ b/app/data/schema.ts
@@ -46,10 +46,24 @@ export const config = table({
   },
 })
 
+export const apiTokens = table({
+  name: 'api_tokens',
+  columns: {
+    id: c.text().primaryKey(),
+    user_id: c.text().notNull(),
+    name: c.text().notNull(),
+    token_hash: c.text().notNull(),
+    prefix: c.text().notNull(),
+    last_used_at: c.integer(),
+    created_at: c.integer().notNull(),
+  },
+})
+
 export type User = TableRow<typeof users>
 export type Sticker = TableRow<typeof stickers>
 export type Invitation = TableRow<typeof invitations>
 export type Config = TableRow<typeof config>
+export type ApiToken = TableRow<typeof apiTokens>
 
 export const UserRoles = {
   User: 'USER',

--- a/app/middleware/csrf-or-bearer.ts
+++ b/app/middleware/csrf-or-bearer.ts
@@ -1,0 +1,28 @@
+import { csrf, type CsrfOptions } from 'remix/middleware/csrf'
+import type { Middleware } from 'remix/router'
+
+/**
+ * Wraps the standard CSRF middleware so that requests to the JSON API surface
+ * (`/api/*`) and requests carrying an `Authorization: Bearer ...` header skip
+ * CSRF entirely. API clients authenticate with bearer tokens (not session
+ * cookies), so the synchronizer token model doesn't apply to them — and they
+ * have no way to read a token anyway. Auth failures inside the API return
+ * 401 (handled by the controller), not a CSRF 403.
+ *
+ * Inside the browser, session-cookie auth + form posts go through CSRF as
+ * usual.
+ */
+export function csrfOrBearer(options?: CsrfOptions): Middleware {
+  const csrfMiddleware = csrf(options)
+  return async (context, next) => {
+    const url = new URL(context.request.url)
+    if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+      return next()
+    }
+    const authHeader = context.request.headers.get('authorization') ?? ''
+    if (/^Bearer\s+\S+/i.test(authHeader)) {
+      return next()
+    }
+    return csrfMiddleware(context, next)
+  }
+}

--- a/app/router.ts
+++ b/app/router.ts
@@ -1,13 +1,15 @@
 import { createRouter, type MiddlewareContext } from 'remix/router'
 import { asyncContext } from 'remix/middleware/async-context'
 import { compression } from 'remix/middleware/compression'
-import { csrf } from 'remix/middleware/csrf'
 import { formData } from 'remix/middleware/form-data'
 import { logger } from 'remix/middleware/logger'
 import { staticFiles } from 'remix/middleware/static'
 
+import { csrfOrBearer } from './middleware/csrf-or-bearer.ts'
+
 import rootController from './actions/controller.tsx'
 import adminController from './actions/admin/controller.tsx'
+import apiController from './actions/api/controller.tsx'
 import changePasswordController from './actions/change-password/controller.tsx'
 import editProfileController from './actions/edit-profile/controller.tsx'
 import editStickerController from './actions/edit-sticker/controller.tsx'
@@ -26,7 +28,7 @@ const stack = [
   staticFiles('./public', { index: false }),
   formData(),
   appSession(),
-  csrf(),
+  csrfOrBearer(),
   asyncContext(),
   loadDatabase(),
   loadAuth(),
@@ -54,5 +56,6 @@ router.map(routes.login, loginController)
 router.map(routes.changePassword, changePasswordController)
 router.map(routes.editProfile, editProfileController)
 router.map(routes.editSticker, editStickerController)
+router.map(routes.api, apiController)
 router.map(routes.removeSticker, removeStickerController)
 router.map(routes.uploadSticker, uploadStickerController)

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,4 +1,4 @@
-import { del, form, get, post, route } from 'remix/routes'
+import { del, form, get, patch, post, route } from 'remix/routes'
 
 export const routes = route({
   // Compiled browser modules.
@@ -51,5 +51,21 @@ export const routes = route({
     deleteUser: post('/users/:id/delete'),
     stickers: get('/stickers'),
     deleteSticker: post('/stickers/:id/delete'),
+  }),
+
+  // API token management (HTML pages, not API endpoints).
+  createApiToken: post('/account/tokens'),
+  revokeApiToken: post('/account/tokens/:id/revoke'),
+
+  // JSON API
+  api: route('/api', {
+    me: get('/me'),
+    stickersIndex: get('/stickers'),
+    stickerShow: get('/stickers/:id'),
+    stickerCreate: post('/stickers'),
+    stickerUpdate: patch('/stickers/:id'),
+    stickerDestroy: del('/stickers/:id'),
+    userShow: get('/users/:username'),
+    userStickers: get('/users/:username/stickers'),
   }),
 })

--- a/migrations/20260601000000_api_tokens/down.sql
+++ b/migrations/20260601000000_api_tokens/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS api_tokens_prefix_idx;
+DROP INDEX IF EXISTS api_tokens_user_id_idx;
+DROP TABLE IF EXISTS api_tokens;

--- a/migrations/20260601000000_api_tokens/up.sql
+++ b/migrations/20260601000000_api_tokens/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE api_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  prefix TEXT NOT NULL,
+  last_used_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX api_tokens_user_id_idx ON api_tokens (user_id);
+CREATE INDEX api_tokens_prefix_idx ON api_tokens (prefix);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,17 +9,24 @@ import { createMigrationRunner } from 'remix/data-table/migrations'
 import { loadMigrations } from 'remix/data-table/migrations/node'
 import { asyncContext } from 'remix/middleware/async-context'
 import { compression } from 'remix/middleware/compression'
-import { csrf } from 'remix/middleware/csrf'
 import { formData } from 'remix/middleware/form-data'
 import { staticFiles } from 'remix/middleware/static'
-import { auth, createSessionAuthScheme } from 'remix/middleware/auth'
+import {
+  auth,
+  createBearerTokenAuthScheme,
+  createSessionAuthScheme,
+} from 'remix/middleware/auth'
 import { session } from 'remix/middleware/session'
+
+import { csrfOrBearer } from '../app/middleware/csrf-or-bearer.ts'
+import { verifyToken } from '../app/data/api-tokens.ts'
 import { createCookie } from 'remix/cookie'
 import { createMemorySessionStorage } from 'remix/session-storage/memory'
 import { createRouter, type MiddlewareContext } from 'remix/router'
 
 import rootController from '../app/actions/controller.tsx'
 import adminController from '../app/actions/admin/controller.tsx'
+import apiController from '../app/actions/api/controller.tsx'
 import changePasswordController from '../app/actions/change-password/controller.tsx'
 import editProfileController from '../app/actions/edit-profile/controller.tsx'
 import editStickerController from '../app/actions/edit-sticker/controller.tsx'
@@ -87,6 +94,15 @@ export async function createTestEnv(): Promise<TestEnv> {
             s.unset('auth')
           },
         }),
+        createBearerTokenAuthScheme<User>({
+          async verify(token, context) {
+            const inner = context.get(Database)
+            if (!inner) return null
+            const match = await verifyToken(inner, token)
+            if (!match) return null
+            return (await inner.findOne(users, { where: { id: match.user_id } })) ?? null
+          },
+        }),
       ],
     })
   }
@@ -96,7 +112,7 @@ export async function createTestEnv(): Promise<TestEnv> {
     staticFiles('./public', { index: false }),
     formData(),
     session(sessionCookie, sessionStorage),
-    csrf(),
+    csrfOrBearer(),
     asyncContext(),
     loadTestDatabase() as any,
     loadTestAuth(),
@@ -114,6 +130,7 @@ export async function createTestEnv(): Promise<TestEnv> {
   router.map(routes.changePassword, changePasswordController as any)
   router.map(routes.editProfile, editProfileController as any)
   router.map(routes.editSticker, editStickerController as any)
+  router.map(routes.api, apiController as any)
   router.map(routes.removeSticker, removeStickerController as any)
   router.map(routes.uploadSticker, uploadStickerController as any)
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -403,6 +403,320 @@ describe('edit sticker', () => {
   })
 })
 
+describe('api tokens', () => {
+  it('creates a token and lets it authenticate api requests', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'ivy', 'ivypass')
+      const sessionCookie = await loginAs(env, 'ivy', 'ivypass')
+
+      // Create a token via the HTML form.
+      const { token: csrfToken, cookie } = await fetchCsrf(
+        env,
+        routes.editProfile.index.href(),
+        sessionCookie,
+      )
+      const body = new FormData()
+      body.set('_csrf', csrfToken)
+      body.set('name', 'test token')
+      const res = await postForm(env, routes.createApiToken.href(), { cookie, body })
+      assert.equal(res.status, 303)
+
+      // Read the flash to recover the plaintext token.
+      const reload = await env.fetch(
+        new Request(buildUrl(routes.editProfile.index.href()), {
+          headers: { cookie: res.headers.get('set-cookie')?.split(';')[0] ?? cookie },
+        }),
+      )
+      const html = await reload.text()
+      const match = html.match(/(st_[0-9a-f]{48})/)
+      assert.ok(match, 'plaintext token should appear in the response once')
+      const plaintext = match[1]!
+
+      // Now hit a write-protected API endpoint with the bearer token.
+      const apiRes = await env.fetch(
+        new Request(buildUrl(routes.api.me.href()), {
+          headers: { authorization: `Bearer ${plaintext}` },
+        }),
+      )
+      assert.equal(apiRes.status, 200)
+      const payload = (await apiRes.json()) as { user: { username: string; id: string } }
+      assert.equal(payload.user.username, 'ivy')
+      assert.equal(payload.user.id, userId)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('revoked tokens stop authenticating', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'jess', 'jesspass')
+
+      // Create a token directly via the data helper.
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext, id: tokenId } = await createTokenForUser(env.db, { id: userId }, 'tok')
+
+      // Sanity: bearer works.
+      const ok = await env.fetch(
+        new Request(buildUrl(routes.api.me.href()), {
+          headers: { authorization: `Bearer ${plaintext}` },
+        }),
+      )
+      assert.equal(ok.status, 200)
+
+      // Revoke via the HTML form.
+      const sessionCookie = await loginAs(env, 'jess', 'jesspass')
+      const { token: csrfToken, cookie } = await fetchCsrf(
+        env,
+        routes.editProfile.index.href(),
+        sessionCookie,
+      )
+      const body = new FormData()
+      body.set('_csrf', csrfToken)
+      const revoke = await postForm(env, routes.revokeApiToken.href({ id: tokenId }), {
+        cookie,
+        body,
+      })
+      assert.equal(revoke.status, 303)
+
+      // Bearer is now rejected.
+      const denied = await env.fetch(
+        new Request(buildUrl(routes.api.me.href()), {
+          headers: { authorization: `Bearer ${plaintext}` },
+        }),
+      )
+      assert.equal(denied.status, 401)
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
+describe('api: stickers', () => {
+  it('GET /api/stickers returns public list without auth', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'kelly', 'kellypass')
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'public sticker',
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(new Request(buildUrl(routes.api.stickersIndex.href())))
+      assert.equal(res.status, 200)
+      const payload = (await res.json()) as { stickers: Array<{ id: string; name: string }> }
+      assert.ok(Array.isArray(payload.stickers))
+      assert.equal(payload.stickers[0]?.name, 'public sticker')
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('GET /api/stickers/:id 404s a missing one', async () => {
+    const env = await createTestEnv()
+    try {
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerShow.href({ id: 'missing' }))),
+      )
+      assert.equal(res.status, 404)
+      const payload = (await res.json()) as { error: string }
+      assert.equal(payload.error, 'Not Found')
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('POST /api/stickers requires bearer auth', async () => {
+    const env = await createTestEnv()
+    try {
+      const body = new FormData()
+      body.set('name', 'not gonna work')
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerCreate.href()), { method: 'POST', body }),
+      )
+      assert.equal(res.status, 401)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('POST /api/stickers creates a sticker with bearer auth', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'liam', 'liampass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: userId }, 'tok')
+
+      // Build a tiny PNG.
+      const sharp = (await import('sharp')).default
+      const png = await sharp({
+        create: { width: 100, height: 100, channels: 3, background: { r: 200, g: 100, b: 100 } },
+      })
+        .png()
+        .toBuffer()
+      const view = new Uint8Array(new ArrayBuffer(png.byteLength))
+      view.set(png)
+      const file = new File([view], 'sticker.png', { type: 'image/png' })
+
+      const body = new FormData()
+      body.set('name', 'api created')
+      body.set('image', file)
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerCreate.href()), {
+          method: 'POST',
+          headers: { authorization: `Bearer ${plaintext}` },
+          body,
+        }),
+      )
+      assert.equal(res.status, 201)
+      const payload = (await res.json()) as {
+        sticker: { id: string; name: string; owner: { username: string } | null }
+      }
+      assert.equal(payload.sticker.name, 'api created')
+      assert.equal(payload.sticker.owner?.username, 'liam')
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('PATCH /api/stickers/:id renames when owned', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'mary', 'marypass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: userId }, 'tok')
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'old',
+        image_url: '/images/banner.png',
+        owner_id: userId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerUpdate.href({ id: stickerId })), {
+          method: 'PATCH',
+          headers: {
+            authorization: `Bearer ${plaintext}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ name: 'new' }),
+        }),
+      )
+      assert.equal(res.status, 200)
+      const payload = (await res.json()) as { sticker: { name: string } }
+      assert.equal(payload.sticker.name, 'new')
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('PATCH /api/stickers/:id forbids non-owner', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'nate', 'natepass')
+      const otherId = await seedUser(env, 'oscar', 'oscarpass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: otherId }, 'tok')
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'natefoo',
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerUpdate.href({ id: stickerId })), {
+          method: 'PATCH',
+          headers: {
+            authorization: `Bearer ${plaintext}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ name: 'taken over' }),
+        }),
+      )
+      assert.equal(res.status, 403)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('DELETE /api/stickers/:id deletes when owned', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'piper', 'piperpass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: userId }, 'tok')
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'going away',
+        image_url: '/images/banner.png',
+        owner_id: userId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerDestroy.href({ id: stickerId })), {
+          method: 'DELETE',
+          headers: { authorization: `Bearer ${plaintext}` },
+        }),
+      )
+      assert.equal(res.status, 204)
+      const remaining = await env.db.find(stickers, stickerId)
+      assert.equal(remaining, null)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('GET /api/users/:username and /stickers return public data', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'quincy', 'quincypass')
+      await env.db.create(stickers, {
+        id: randomUUID(),
+        name: 'q1',
+        image_url: '/images/banner.png',
+        owner_id: userId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const userRes = await env.fetch(
+        new Request(buildUrl(routes.api.userShow.href({ username: 'quincy' }))),
+      )
+      assert.equal(userRes.status, 200)
+      const userPayload = (await userRes.json()) as { user: { username: string } }
+      assert.equal(userPayload.user.username, 'quincy')
+
+      const stickersRes = await env.fetch(
+        new Request(buildUrl(routes.api.userStickers.href({ username: 'quincy' }))),
+      )
+      assert.equal(stickersRes.status, 200)
+      const stickersPayload = (await stickersRes.json()) as {
+        stickers: Array<{ name: string }>
+      }
+      assert.equal(stickersPayload.stickers[0]?.name, 'q1')
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
 describe('dev logs', () => {
   it('renders the dev logs index', async () => {
     const env = await createTestEnv()


### PR DESCRIPTION
Adds a small REST API at `/api/*` plus per-user API tokens.

## Endpoints

| Method | Path                                | Auth     | Notes |
|--------|-------------------------------------|----------|-------|
| GET    | /api/stickers                       | optional | paginated |
| GET    | /api/stickers/:id                   | optional | |
| POST   | /api/stickers                       | **required** | multipart (name, image) |
| PATCH  | /api/stickers/:id                   | **required** | json or form, owner/admin |
| DELETE | /api/stickers/:id                   | **required** | owner/admin |
| GET    | /api/me                             | **required** | |
| GET    | /api/users/:username                | optional | |
| GET    | /api/users/:username/stickers       | optional | |

## Tokens

- New `api_tokens` table. Tokens are bcrypt-hashed; we store a 12-char prefix for lookup.
- Look like `st_<48 hex>` for easy spotting / secret scanning.
- Manage on `/account/profile` → 'api tokens'. Plaintext shown exactly once in a one-time flash box.
- New `createBearerTokenAuthScheme` added to the existing `auth()` middleware so the same `getCurrentUser()` works for both session cookies and bearer tokens (and so does the same controller `requireAuth`-shaped pattern).

## CSRF interplay

The existing CSRF middleware was 403'ing API POSTs. Wrapped in `csrfOrBearer` which skips when:
- the path is `/api/*`, or
- the request carries an `Authorization: Bearer` header

Inside the browser, session-cookie auth + form POSTs still go through CSRF.

## Tests

27/27 (10 new): token creation + bearer authn, revoked tokens stop working, public reads, 401/403 cases on writes, JSON-body PATCH, multipart POST, DELETE returns 204.