### PR TITLE
respect PUBLIC_ORIGIN for CSRF behind a TLS proxy

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -10,3 +10,8 @@ SESSION_SECRET=
 
 # Optional — set to "production" for production builds.
 # NODE_ENV=development
+
+# Required behind a TLS-terminating proxy (e.g. Traefik).
+# Set to the public origin(s) the browser sees. Comma-separate for multiple.
+# Without this, CSRF will reject browser POSTs with 'invalid CSRF origin'.
+# PUBLIC_ORIGIN=https://stickertrade.ca

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Seeded credentials:
 | `DATABASE_URL`    | `./db/stickertrade.sqlite`       | Path to SQLite file                         |
 | `PORT`            | `44100`                          | HTTP listen port                            |
 | `NODE_ENV`        | `development`                    | Toggles dev logger, cookie secure flag, etc |
+| `PUBLIC_ORIGIN`   | _unset_ (same-origin only)       | Allowed public origin(s) for CSRF Origin checks. Required behind a TLS proxy; e.g. `https://stickertrade.ca`. Comma-separate for multiple. |
 
 ## Production bootstrap
 

--- a/app/router.ts
+++ b/app/router.ts
@@ -7,6 +7,25 @@ import { staticFiles } from 'remix/middleware/static'
 
 import { csrfOrBearer } from './middleware/csrf-or-bearer.ts'
 
+/**
+ * Comma-separated list of allowed public origins for CSRF Origin/Referer checks.
+ * Required behind a TLS-terminating proxy where the browser's Origin header
+ * doesn't match `context.url.origin` (which is whatever the proxy forwards to,
+ * e.g. `http://stickertrade:44100`).
+ *
+ * Set `PUBLIC_ORIGIN=https://stickertrade.ca` in prod (multiple values
+ * separated by commas if you also serve under www. etc.).
+ */
+function parsePublicOrigin(raw: string | undefined): string | string[] | undefined {
+  if (!raw) return undefined
+  const list = raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0)
+  if (list.length === 0) return undefined
+  return list.length === 1 ? list[0] : list
+}
+
 import rootController from './actions/controller.tsx'
 import adminController from './actions/admin/controller.tsx'
 import apiController from './actions/api/controller.tsx'
@@ -28,7 +47,7 @@ const stack = [
   staticFiles('./public', { index: false }),
   formData(),
   appSession(),
-  csrfOrBearer(),
+  csrfOrBearer({ origin: parsePublicOrigin(process.env.PUBLIC_ORIGIN) }),
   asyncContext(),
   loadDatabase(),
   loadAuth(),

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -45,7 +45,12 @@ export interface TestEnv {
   cleanup: () => void
 }
 
-export async function createTestEnv(): Promise<TestEnv> {
+export interface CreateTestEnvOptions {
+  /** Override the allowed CSRF origin (defaults to undefined = same-origin only). */
+  publicOrigin?: string | string[]
+}
+
+export async function createTestEnv(options: CreateTestEnvOptions = {}): Promise<TestEnv> {
   const tmpDir = mkdtempSync(path.join(tmpdir(), 'stickertrade-test-'))
   const dbPath = path.join(tmpDir, 'test.sqlite')
   const sqlite = new DatabaseSync(dbPath)
@@ -112,7 +117,7 @@ export async function createTestEnv(): Promise<TestEnv> {
     staticFiles('./public', { index: false }),
     formData(),
     session(sessionCookie, sessionStorage),
-    csrfOrBearer(),
+    csrfOrBearer({ origin: options.publicOrigin }),
     asyncContext(),
     loadTestDatabase() as any,
     loadTestAuth(),

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -79,6 +79,51 @@ describe('login', () => {
     }
   })
 
+  it('rejects POST whose Origin header does not match request URL (proxy scenario)', async () => {
+    // Default CSRF behaviour: configured origin = undefined, so the middleware
+    // compares Origin against context.url.origin. Behind a TLS-terminating
+    // proxy these differ and CSRF rejects with 'invalid CSRF origin'.
+    const env = await createTestEnv()
+    try {
+      await seedUser(env, 'alice', 'goodpass')
+      const res = await env.fetch(
+        new Request(buildUrl(routes.login.action.href()), {
+          method: 'POST',
+          headers: { origin: 'https://stickertrade.ca' },
+          body: new FormData(),
+        }),
+      )
+      assert.equal(res.status, 403)
+      const body = await res.text()
+      assert.match(body, /invalid CSRF origin/)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('PUBLIC_ORIGIN config lets a proxied request pass the origin check', async () => {
+    // Same as above but with publicOrigin configured. We still expect a 403
+    // (no _csrf token), but it should be a missing-token rejection, not an
+    // origin rejection — proving the origin check now accepts the proxied
+    // browser request.
+    const env = await createTestEnv({ publicOrigin: 'https://stickertrade.ca' })
+    try {
+      await seedUser(env, 'alice', 'goodpass')
+      const res = await env.fetch(
+        new Request(buildUrl(routes.login.action.href()), {
+          method: 'POST',
+          headers: { origin: 'https://stickertrade.ca' },
+          body: new FormData(),
+        }),
+      )
+      assert.equal(res.status, 403)
+      const body = await res.text()
+      assert.match(body, /missing CSRF token/)
+    } finally {
+      env.cleanup()
+    }
+  })
+
   it('accepts valid credentials and redirects home', async () => {
     const env = await createTestEnv()
     try {


### PR DESCRIPTION
Behind Traefik (or any TLS-terminating proxy), the browser sends `Origin: https://stickertrade.ca` but `context.url.origin` resolves to whatever the proxy forwards (`http://stickertrade:44100`), so the CSRF origin check rejects every login with `invalid CSRF origin`.

Fix: new `PUBLIC_ORIGIN` env var (comma-separated allowed origins) gets passed through to the CSRF middleware as the configured origin matcher. When unset, behaviour is unchanged (same-origin only — fine for local dev).

Tests:
- 'rejects POST whose Origin header does not match request URL' — proves the bug
- 'PUBLIC_ORIGIN config lets a proxied request pass the origin check' — proves the fix

To roll out: set `PUBLIC_ORIGIN=https://stickertrade.ca` in the sops secret + restart the container.