### PR TITLE
opengraph tags + roadmap cleanup

### DIFF
--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -247,7 +247,12 @@ export default createController(routes, {
       return context.render(
         <DevLogPage
           user={getCurrentUser(context)}
-          log={{ title: log.title, dateString: log.dateString, html: log.html }}
+          log={{
+            slug: log.slug,
+            title: log.title,
+            dateString: log.dateString,
+            html: log.html,
+          }}
         />,
       )
     },

--- a/app/actions/dev-log-page.tsx
+++ b/app/actions/dev-log-page.tsx
@@ -1,5 +1,6 @@
 import { css } from 'remix/ui'
 
+import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { colors } from '../ui/theme.ts'
@@ -10,9 +11,18 @@ export function DevLogPage() {
     log,
   }: {
     user: HeaderUser | null
-    log: { title: string; dateString: string; html: string }
+    log: { slug: string; title: string; dateString: string; html: string }
   }) => (
-    <Document title={`stickertrade - dev log | ${log.title}`} user={user}>
+    <Document
+      title={`stickertrade - dev log | ${log.title}`}
+      user={user}
+      og={{
+        title: log.title,
+        description: `stickertrade dev log from ${log.dateString}`,
+        url: routes.devLog.href({ slug: log.slug }),
+        type: 'article',
+      }}
+    >
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '0.5rem' })}>dev log {log.title}</h1>
         <p mix={css({ fontStyle: 'italic', opacity: 0.6, marginBottom: '1rem' })}>

--- a/app/actions/home-page.tsx
+++ b/app/actions/home-page.tsx
@@ -1,5 +1,6 @@
 import { css } from 'remix/ui'
 
+import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { StickerCard, UploadStickerCard, type StickerCardSticker } from '../ui/sticker-card.tsx'
@@ -13,7 +14,14 @@ export interface HomePageProps {
 
 export function HomePage() {
   return ({ user, stickers, users }: HomePageProps) => (
-    <Document user={user}>
+    <Document
+      user={user}
+      og={{
+        title: 'stickertrade',
+        description: 'invite-only sticker trading site',
+        url: routes.home.href(),
+      }}
+    >
       <main>
         <p mix={sectionHeading}>recently posted stickers</p>
         <div mix={gridStyle}>

--- a/app/actions/profile-page.tsx
+++ b/app/actions/profile-page.tsx
@@ -19,8 +19,22 @@ export interface ProfilePageProps {
 export function ProfilePage() {
   return ({ user, profile }: ProfilePageProps) => {
     const isOwner = user?.username === profile.username
+    const stickerCount = profile.stickers.length
     return (
-      <Document title={`stickertrade - ${profile.username}`} user={user}>
+      <Document
+        title={`stickertrade - ${profile.username}`}
+        user={user}
+        og={{
+          title: `${profile.username} on stickertrade`,
+          description:
+            stickerCount === 0
+              ? `${profile.username} hasn't uploaded any stickers yet`
+              : `${stickerCount} sticker${stickerCount === 1 ? '' : 's'} by ${profile.username}`,
+          image: profile.avatar_url ?? '/images/default-avatar.webp',
+          url: routes.profile.href({ username: profile.username }),
+          type: 'profile',
+        }}
+      >
         <main>
           <div mix={profileHeaderStyle}>
             <img

--- a/app/actions/sticker-page.tsx
+++ b/app/actions/sticker-page.tsx
@@ -20,8 +20,19 @@ export function StickerPage() {
   return ({ user, sticker }: StickerPageProps) => {
     const canEdit =
       user != null && (user.username === sticker.owner?.username || user.role === 'ADMIN')
+    const ownerLabel = sticker.owner ? `by ${sticker.owner.username}` : '(no owner)'
     return (
-      <Document title={`stickertrade - ${sticker.name}`} user={user}>
+      <Document
+        title={`stickertrade - ${sticker.name}`}
+        user={user}
+        og={{
+          title: sticker.name,
+          description: `sticker ${ownerLabel}`,
+          image: sticker.image_url,
+          url: routes.sticker.href({ id: sticker.id }),
+          type: 'article',
+        }}
+      >
         <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
           <div mix={imageWrapStyle}>
             <img src={sticker.image_url} alt={sticker.name} mix={imageStyle} />

--- a/app/data/public-origin.ts
+++ b/app/data/public-origin.ts
@@ -1,0 +1,28 @@
+/**
+ * Resolves the public origin used to build absolute URLs (e.g. og:image,
+ * og:url). Defaults to localhost for dev; configure PUBLIC_ORIGIN in prod
+ * (this is the same env var the CSRF middleware uses for origin matching).
+ *
+ * If PUBLIC_ORIGIN is comma-separated (multiple allowed origins for CSRF),
+ * the first entry is used as the canonical public URL.
+ */
+function resolveDefaultOrigin(): string {
+  const raw = process.env.PUBLIC_ORIGIN
+  if (!raw) return `http://localhost:${process.env.PORT ?? '44100'}`
+  const first = raw.split(',').map((v) => v.trim()).find((v) => v.length > 0)
+  return first ?? `http://localhost:${process.env.PORT ?? '44100'}`
+}
+
+const DEFAULT_ORIGIN = resolveDefaultOrigin()
+
+export function getPublicOrigin(): string {
+  return DEFAULT_ORIGIN
+}
+
+/** Make a relative path absolute against the configured public origin. */
+export function absoluteUrl(pathOrUrl: string): string {
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl
+  const origin = DEFAULT_ORIGIN.replace(/\/+$/, '')
+  const path = pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`
+  return origin + path
+}

--- a/app/data/roadmap.ts
+++ b/app/data/roadmap.ts
@@ -7,53 +7,136 @@ function md(input: string): string {
 }
 
 const sourceTasks: Array<Omit<RoadmapTask, 'id'>> = [
+  // ---- Recently shipped (kept for transparency) ----
+  {
+    title: 'Port to Remix 3 ⚛️',
+    description: md(`
+- [x] Re-wrote the entire site on Remix 3 beta
+- [x] Replaced Prisma with remix/data-table + node:sqlite
+- [x] Replaced Tailwind with remix/ui css() mixins
+- [x] Dropped the Minio sidecar; sticker uploads go to a local fs volume
+`),
+  },
+  {
+    title: 'Production deploy 🚢',
+    description: md(`
+- [x] Multi-stage Dockerfile published to ghcr.io
+- [x] node-tsx in-place TS, no separate build step
+- [x] Auto-applied migrations on container boot
+- [x] Bootstrap-admin CLI for first prod login
+`),
+  },
   {
     title: 'Admin Page 🤴',
     description: md(`
-- [ ] Methods to delete stickers
-- [ ] Refine table interactions / plumbing
+- [x] Delete users
+- [x] Delete stickers
+- [x] Refined table plumbing (per-row POST actions, no multi-select modal)
 `),
   },
   {
     title: 'Testing 🧪',
-    focus: true,
     description: md(`
 - [x] node --test setup for backend integration testing
-- [ ] tested invitations
-- [ ] tested login
+- [x] Tested login (good + bad creds, CSRF rejection)
+- [x] Tested invitations (generate, accept, reject)
+- [x] Tested admin (auth gate, delete sticker)
+- [x] Tested edit profile + change password
+- [x] Tested edit sticker (owner + non-owner)
+- [x] Tested API (bearer auth, public reads, CRUD, ownership)
 `),
   },
-  { title: 'Users Search 👤' },
   {
-    title: 'Dedicated stickers page 🖼️',
+    title: 'Profile editing 👤',
     description: md(`
-- [ ] Paginated list of stickers
-- [ ] Searching
-- [ ] Filters
+- [x] Avatar upload (sharp-resized, center-cropped to 512×512)
+- [x] Remove avatar
+- [x] Change password (with current-password re-verification)
 `),
   },
-  { title: 'Friends 👪' },
-  { title: 'Edit Sticker ➕', eventually: true },
-  { title: 'Users rough location 📍', eventually: true },
-  { title: 'Edit profile page 👤', eventually: true },
+  {
+    title: 'Edit sticker ➕',
+    description: md(`
+- [x] Rename
+- [x] Replace image
+- [x] Owner + admin gate
+`),
+  },
+  {
+    title: 'Security hardening 🔒',
+    description: md(`
+- [x] CSRF middleware on every state-changing form
+- [x] Session ID rotation on login / logout / password change
+- [x] PUBLIC_ORIGIN env var for proxies (TLS terminator behind the app)
+- [x] Bcrypt password hashing
+`),
+  },
+  {
+    title: 'JSON API 🔌',
+    description: md(`
+- [x] REST endpoints for stickers (CRUD)
+- [x] /api/me, /api/users/:username, /api/users/:username/stickers
+- [x] Bearer-token auth, hashed at rest, prefix lookup
+- [x] Per-user token management UI on /account/profile
+`),
+  },
+
+  // ---- Currently in focus ----
+  {
+    title: 'Opengraph images 🖼️',
+    focus: true,
+    description: md(`
+- [ ] Per-sticker og:image, og:title, og:description
+- [ ] Per-profile og:image (avatar), og:title (username)
+- [ ] Site-wide defaults
+`),
+  },
+
+  // ---- Up next ----
+  {
+    title: 'Stickers index polish 📚',
+    description: md(`
+- [ ] Pagination (replace the current load-1000 query)
+- [ ] Text search by name
+- [ ] Filter by owner
+`),
+  },
+  { title: 'Users search 🔎' },
+  { title: 'Toasts 🍞' },
+
+  // ---- Future / not yet committed ----
+  {
+    title: 'Trading 💱 (the actual feature)',
+    eventually: true,
+    description: md(`
+- [ ] Propose a 1-for-1 trade
+- [ ] Accept / reject / cancel proposals
+- [ ] Trade history / provenance per sticker
+`),
+  },
+  { title: 'Friends 👪', eventually: true },
   {
     title: 'Social associations 🙋‍♂️',
     eventually: true,
     description: md(`
-- [ ] Discord association (oauth?)
-- [ ] Twitter association (oauth?)
+- [ ] Discord login (replaces or supplements invite-only signup?)
+- [ ] Twitter/X association (display only)
 - [ ] Disassociation
 `),
   },
-  { title: 'Events 📅', eventually: true },
-  { title: 'Create Event 📅', eventually: true },
-  { title: 'Events Map 📍', eventually: true },
-  { title: 'Trading 💱', eventually: true },
-  { title: 'Opengraph Images 🖼️', eventually: true },
-  { title: 'Toasts 🍞', eventually: true },
-  { title: 'Sticker Image Cropping 🖼️', eventually: true },
+  { title: 'Users rough location 📍', eventually: true },
   {
-    title: 'Accessibility Audit 🧐',
+    title: 'Events 📅',
+    eventually: true,
+    description: md(`
+- [ ] List events
+- [ ] Create event
+- [ ] Events map
+`),
+  },
+  { title: 'Sticker image cropping 🖼️ (like avatars)', eventually: true },
+  {
+    title: 'Accessibility audit 🧐',
     eventually: true,
     description: md(`
 - [ ] Color contrast review

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -1,9 +1,10 @@
 import { css, type RemixNode } from 'remix/ui'
 
 import { routes } from '../routes.ts'
-import { colors } from './theme.ts'
-import { Header, type HeaderUser } from './header.tsx'
 import { Footer } from './footer.tsx'
+import { Header, type HeaderUser } from './header.tsx'
+import { OgTags, type OgTagsProps } from './og-tags.tsx'
+import { colors } from './theme.ts'
 
 export interface DocumentProps {
   children?: RemixNode
@@ -11,6 +12,11 @@ export interface DocumentProps {
   title?: string
   user?: HeaderUser | null
   showChrome?: boolean
+  /**
+   * Open Graph metadata for this page. Pages that don't supply one get a
+   * site-default set of tags from `OgTags` (banner image, generic copy).
+   */
+  og?: Partial<OgTagsProps>
 }
 
 const DEFAULT_TITLE = 'stickertrade'
@@ -22,13 +28,14 @@ export function Document() {
     title = DEFAULT_TITLE,
     user = null,
     showChrome = true,
+    og,
   }: DocumentProps) => (
     <html lang="en" mix={css({ height: '100%' })}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <meta property="og:image" content="/images/banner.png" />
+        <OgTags title={og?.title ?? title} {...og} />
         <title>{title}</title>
         {head}
       </head>

--- a/app/ui/og-tags.tsx
+++ b/app/ui/og-tags.tsx
@@ -1,0 +1,55 @@
+import type { Handle } from 'remix/ui'
+
+import { absoluteUrl } from '../data/public-origin.ts'
+
+export interface OgTagsProps {
+  /** Page title used for og:title + twitter:title. */
+  title: string
+  /** Page description; falls back to a sensible site default. */
+  description?: string
+  /**
+   * Image URL. Relative paths are resolved against the configured
+   * `PUBLIC_ORIGIN` since OG scrapers require absolute URLs.
+   */
+  image?: string
+  /** Canonical URL for this page. Required for og:url to be useful. */
+  url?: string
+  /** Open Graph type; defaults to 'website'. */
+  type?: 'website' | 'article' | 'profile'
+}
+
+const DEFAULT_DESCRIPTION = 'invite-only sticker trading site'
+
+export function OgTags(handle: Handle<OgTagsProps>) {
+  return () => {
+    const {
+      title,
+      description = DEFAULT_DESCRIPTION,
+      image = '/images/banner.png',
+      url,
+      type = 'website',
+    } = handle.props
+    const absImage = absoluteUrl(image)
+    const absUrl = url ? absoluteUrl(url) : undefined
+    return (
+      <>
+        {/* Open Graph */}
+        <meta property="og:site_name" content="stickertrade" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={absImage} />
+        <meta property="og:type" content={type} />
+        {absUrl ? <meta property="og:url" content={absUrl} /> : null}
+
+        {/* Twitter cards */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={absImage} />
+
+        {/* Plain description so search engines and clients without OG still get it */}
+        <meta name="description" content={description} />
+      </>
+    )
+  }
+}

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -762,6 +762,63 @@ describe('api: stickers', () => {
   })
 })
 
+describe('og tags', () => {
+  it('home page emits site-level og:image and og:title', async () => {
+    const env = await createTestEnv()
+    try {
+      const res = await env.fetch(new Request(buildUrl(routes.home.href())))
+      const html = await res.text()
+      assert.match(html, /<meta property="og:title" content="stickertrade"/)
+      assert.match(html, /<meta property="og:image" content="http:\/\/localhost(:\d+)?\/images\/banner\.png"/)
+      assert.match(html, /<meta name="twitter:card" content="summary_large_image"/)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('sticker page emits per-sticker og:title + og:image (absolute)', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'roxie', 'roxiepass')
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'cool og sticker',
+        image_url: '/uploads/stickers/cool.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(new Request(buildUrl(routes.sticker.href({ id: stickerId }))))
+      const html = await res.text()
+      assert.match(html, /<meta property="og:title" content="cool og sticker"/)
+      assert.match(html, /<meta property="og:image" content="http:\/\/localhost(:\d+)?\/uploads\/stickers\/cool\.png"/)
+      assert.match(html, /<meta property="og:description" content="sticker by roxie"/)
+      assert.match(html, /<meta property="og:type" content="article"/)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('profile page emits per-profile og:title + og:image', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'sami', 'samipass')
+      await env.db.update(users, userId, { avatar_url: '/uploads/avatars/sami.png' })
+      const res = await env.fetch(
+        new Request(buildUrl(routes.profile.href({ username: 'sami' }))),
+      )
+      const html = await res.text()
+      assert.match(html, /<meta property="og:title" content="sami on stickertrade"/)
+      assert.match(html, /<meta property="og:image" content="http:\/\/localhost(:\d+)?\/uploads\/avatars\/sami\.png"/)
+      assert.match(html, /<meta property="og:type" content="profile"/)
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
 describe('dev logs', () => {
   it('renders the dev logs index', async () => {
     const env = await createTestEnv()


### PR DESCRIPTION
Two small things.

## Opengraph tags

Sticker URLs shared in Discord/iMessage/Twitter now unfurl with the sticker image. Profile URLs unfurl with the avatar.

- New `<OgTags />` component emits a full set of og:* + twitter:* + meta description tags.
- Relative image paths resolve to absolute via `PUBLIC_ORIGIN` (or `http://localhost:PORT` in dev), since OG scrapers reject relative URLs.
- Per-page tags: stickers (image, owner, type=article), profiles (avatar, sticker count, type=profile), dev logs (title, date, type=article). Home page emits the clean site-default set.

## Roadmap cleanup

The displayed roadmap was still showing 'Admin Page', 'Testing', 'Edit Sticker', and 'Edit profile page' as todo items — all of which shipped during the port. Marked everything done, added context for what was actually built, promoted 'opengraph images' to focus, queued 'stickers index polish' + 'users search' + 'toasts' as up-next.

Tests: 32 passing (3 new for OG tags on home / sticker / profile).