### PR TITLE
better upload errors: handle at the route boundary (skill-aligned)

### DIFF
--- a/app/actions/api/controller.tsx
+++ b/app/actions/api/controller.tsx
@@ -6,9 +6,10 @@ import { createController } from 'remix/router'
 
 import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers, users } from '../../data/schema.ts'
-import { processStickerUpload } from '../../data/upload-image.ts'
+import { ProcessImageError, processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
+import { readUploadFormData } from '../../utils/upload.ts'
 import { jsonError, jsonOk } from './json.ts'
 import { serializeSticker, serializeUser, serializeUserStub } from './serializers.ts'
 
@@ -85,7 +86,15 @@ export default createController(routes.api, {
       const user = getCurrentUser(context)
       if (!user) return jsonError(401, 'Unauthorized')
 
-      const formData = context.get(FormData)
+      const parsed = await readUploadFormData(context.request)
+      if (!parsed.success) {
+        return jsonError(parsed.error.status, parsed.error.code, {
+          message: parsed.error.message,
+          ...parsed.error.extras,
+        })
+      }
+      const formData = parsed.value
+
       const name = String(formData.get('name') ?? '').trim()
       const file = formData.get('image')
 
@@ -96,13 +105,19 @@ export default createController(routes.api, {
       if (!(file instanceof File) || file.size === 0) {
         issues.push({ path: ['image'], message: 'Please attach an image' })
       }
-      if (issues.length > 0) return jsonError(400, 'Validation failed', issues)
+      if (issues.length > 0) return jsonError(400, 'Validation failed', { issues })
 
       let storedImageUrl: string
       try {
         storedImageUrl = await processStickerUpload(file as File)
       } catch (error) {
-        return jsonError(400, error instanceof Error ? error.message : 'Upload failed')
+        if (error instanceof ProcessImageError) {
+          const status = error.code === 'file_too_large' ? 413 : 400
+          return jsonError(status, error.code, { message: error.message })
+        }
+        return jsonError(400, 'upload_failed', {
+          message: error instanceof Error ? error.message : 'Upload failed',
+        })
       }
 
       const db = context.get(Database)
@@ -148,9 +163,9 @@ export default createController(routes.api, {
 
       const name = typeof payload.name === 'string' ? payload.name.trim() : ''
       if (name.length === 0 || name.length > 60) {
-        return jsonError(400, 'Validation failed', [
-          { path: ['name'], message: 'Name must be 1-60 characters' },
-        ])
+        return jsonError(400, 'Validation failed', {
+          issues: [{ path: ['name'], message: 'Name must be 1-60 characters' }],
+        })
       }
 
       await db.update(stickers, sticker.id, { name, updated_at: Date.now() })

--- a/app/actions/api/json.ts
+++ b/app/actions/api/json.ts
@@ -1,15 +1,25 @@
 /**
  * JSON response helpers for the /api/* surface.
  *
- * Keeps response construction terse and consistent across controllers:
- *   return jsonOk({ sticker: ... })
- *   return jsonError(404, 'Not Found')
+ * Three response shapes for errors:
+ *
+ *   // simple message error
+ *   jsonError(404, 'Not Found')
+ *   // -> { "error": "Not Found" }
+ *
+ *   // validation failure with structured issues
+ *   jsonError(400, 'Validation failed', { issues: [...] })
+ *   // -> { "error": "Validation failed", "issues": [...] }
+ *
+ *   // tagged error with a human message + extra context
+ *   jsonError(413, 'file_too_large', { message: 'image is too large...', max_bytes: 10485760 })
+ *   // -> { "error": "file_too_large", "message": "image is too large...", "max_bytes": 10485760 }
+ *
+ * The third shape is what the rest of the codebase calls a "tagged" error:
+ * the `error` field is a stable code like `file_too_large`, and the
+ * `message` field carries the human-friendly description. API clients can
+ * branch on `error` to display the right UI without parsing the message.
  */
-
-export interface ApiErrorBody {
-  error: string
-  issues?: unknown
-}
 
 const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' }
 
@@ -20,8 +30,24 @@ export function jsonOk(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-export function jsonError(status: number, error: string, issues?: unknown): Response {
-  const body: ApiErrorBody = issues ? { error, issues } : { error }
+export interface JsonErrorOptions {
+  /** Human-friendly message. Shown alongside the error code. */
+  message?: string
+  /** Structured validation issues, e.g. from a schema parse failure. */
+  issues?: unknown
+  /** Extra fields merged into the body for context (e.g. `max_bytes`). */
+  [key: string]: unknown
+}
+
+export function jsonError(
+  status: number,
+  error: string,
+  options: JsonErrorOptions = {},
+): Response {
+  const { message, issues, ...extras } = options
+  const body: Record<string, unknown> = { error, ...extras }
+  if (message != null) body.message = message
+  if (issues != null) body.issues = issues
   return new Response(JSON.stringify(body), {
     status,
     headers: JSON_HEADERS,

--- a/app/actions/edit-profile/controller.tsx
+++ b/app/actions/edit-profile/controller.tsx
@@ -9,6 +9,8 @@ import { users } from '../../data/schema.ts'
 import { processAvatarUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
+import { assertCsrfToken } from '../../utils/csrf.ts'
+import { readUploadFormData } from '../../utils/upload.ts'
 import { EditProfilePage } from '../edit-profile-page.tsx'
 
 async function safeRemoveStoredUpload(url: string | null) {
@@ -74,7 +76,30 @@ export default createController(routes.editProfile, {
       if (!user) return redirect(routes.login.index.href(), 303)
 
       const db = context.get(Database)
-      const formData = context.get(FormData)
+
+      // Two flows hit this action: the multipart avatar upload form and the
+      // url-encoded "remove avatar" button. The global form-data middleware
+      // parses the url-encoded body for us; the multipart body we parse
+      // ourselves so we can render proper upload-too-large errors inline.
+      const contentType = context.request.headers.get('content-type') ?? ''
+      const isMultipart = contentType.startsWith('multipart/form-data')
+
+      let formData: FormData
+      if (isMultipart) {
+        const parsed = await readUploadFormData(context.request)
+        if (!parsed.success) {
+          return context.render(
+            <EditProfilePage user={user} avatarErrors={{ avatar: parsed.error.message }} />,
+            { status: parsed.error.status },
+          )
+        }
+        formData = parsed.value
+        const denied = assertCsrfToken(context, formData.get('_csrf'))
+        if (denied) return denied
+      } else {
+        formData = context.get(FormData)
+      }
+
       const intent = String(formData.get('action') ?? '')
 
       // Read the row fresh so we delete the correct previous file (the
@@ -108,11 +133,9 @@ export default createController(routes.editProfile, {
       try {
         storedUrl = await processAvatarUpload(file)
       } catch (error) {
+        const message = error instanceof Error ? error.message : 'Upload failed'
         return context.render(
-          <EditProfilePage
-            user={user}
-            avatarErrors={{ avatar: error instanceof Error ? error.message : 'Upload failed' }}
-          />,
+          <EditProfilePage user={user} avatarErrors={{ avatar: message }} />,
           { status: 400 },
         )
       }

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -8,6 +8,8 @@ import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
+import { assertCsrfToken } from '../../utils/csrf.ts'
+import { readUploadFormData } from '../../utils/upload.ts'
 import { EditStickerPage } from '../edit-sticker-page.tsx'
 
 function notFound() {
@@ -61,7 +63,33 @@ export default createController(routes.editSticker, {
         return new Response('Forbidden', { status: 403 })
       }
 
-      const formData = context.get(FormData)
+      // Two flows hit this action: a multipart submit with a new image,
+      // or a url-encoded submit that only changes the name. The global
+      // form-data middleware parses the url-encoded body for us; we parse
+      // the multipart body here so upload-too-large errors render inline.
+      const contentType = context.request.headers.get('content-type') ?? ''
+      const isMultipart = contentType.startsWith('multipart/form-data')
+
+      let formData: FormData
+      if (isMultipart) {
+        const parsed = await readUploadFormData(context.request)
+        if (!parsed.success) {
+          return context.render(
+            <EditStickerPage
+              user={user}
+              sticker={{ id: sticker.id, name: sticker.name, image_url: sticker.image_url }}
+              errors={{ image: parsed.error.message }}
+            />,
+            { status: parsed.error.status },
+          )
+        }
+        formData = parsed.value
+        const denied = assertCsrfToken(context, formData.get('_csrf'))
+        if (denied) return denied
+      } else {
+        formData = context.get(FormData)
+      }
+
       const name = String(formData.get('name') ?? '').trim()
       const file = formData.get('image')
       const hasNewImage = file instanceof File && file.size > 0
@@ -96,11 +124,12 @@ export default createController(routes.editSticker, {
         try {
           storedUrl = await processStickerUpload(file as File)
         } catch (error) {
+          const message = error instanceof Error ? error.message : 'Upload failed'
           return context.render(
             <EditStickerPage
               user={user}
               sticker={{ id: sticker.id, name, image_url: sticker.image_url }}
-              errors={{ image: error instanceof Error ? error.message : 'Upload failed' }}
+              errors={{ image: message }}
             />,
             { status: 400 },
           )

--- a/app/actions/upload-sticker/controller.tsx
+++ b/app/actions/upload-sticker/controller.tsx
@@ -8,6 +8,8 @@ import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { routes } from '../../routes.ts'
+import { assertCsrfToken } from '../../utils/csrf.ts'
+import { readUploadFormData } from '../../utils/upload.ts'
 import { UploadStickerPage } from '../upload-sticker-page.tsx'
 
 export default createController(routes.uploadSticker, {
@@ -22,7 +24,18 @@ export default createController(routes.uploadSticker, {
       const user = getCurrentUser(context)
       if (!user) return redirect(routes.login.index.href(), 303)
 
-      const formData = context.get(FormData)
+      const parsed = await readUploadFormData(context.request)
+      if (!parsed.success) {
+        return context.render(
+          <UploadStickerPage user={user} errors={{ image: parsed.error.message }} />,
+          { status: parsed.error.status },
+        )
+      }
+      const formData = parsed.value
+
+      const denied = assertCsrfToken(context, formData.get('_csrf'))
+      if (denied) return denied
+
       const name = String(formData.get('name') ?? '').trim()
       const file = formData.get('image')
 
@@ -45,12 +58,9 @@ export default createController(routes.uploadSticker, {
       try {
         storedImageUrl = await processStickerUpload(file as File)
       } catch (error) {
+        const message = error instanceof Error ? error.message : 'Upload failed'
         return context.render(
-          <UploadStickerPage
-            user={user}
-            errors={{ image: error instanceof Error ? error.message : 'Upload failed' }}
-            values={{ name }}
-          />,
+          <UploadStickerPage user={user} errors={{ image: message }} values={{ name }} />,
           { status: 400 },
         )
       }

--- a/app/data/upload-image.ts
+++ b/app/data/upload-image.ts
@@ -7,6 +7,21 @@ import { uploadStorage } from './uploads.ts'
 const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp'])
 const MAX_BYTES = 10 * 1024 * 1024 // 10 MB
 
+/**
+ * Typed errors thrown by `processImageUpload`. Controllers can branch on
+ * `error.code` to render a stable error code (in JSON) or a friendly
+ * message (in HTML).
+ */
+export class ProcessImageError extends Error {
+  constructor(
+    public readonly code: 'unsupported_image_type' | 'file_too_large',
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ProcessImageError'
+  }
+}
+
 export interface ProcessImageOptions {
   /** Subdirectory under tmp/uploads to store the file in. */
   folder: string
@@ -22,16 +37,24 @@ export interface ProcessImageOptions {
 /**
  * Validate, optimize, and persist an image upload. Returns the public URL
  * to use for the resulting database column (e.g. avatar_url, image_url).
+ * Throws `ProcessImageError` for expected validation failures so
+ * controllers can render them as user-facing responses.
  */
 export async function processImageUpload(
   file: File,
   options: ProcessImageOptions,
 ): Promise<string> {
   if (!ALLOWED_TYPES.has(file.type)) {
-    throw new Error(`unsupported image type: ${file.type}`)
+    throw new ProcessImageError(
+      'unsupported_image_type',
+      'unsupported image type; please upload a png or jpeg',
+    )
   }
   if (file.size > MAX_BYTES) {
-    throw new Error(`image too large (max ${MAX_BYTES / 1024 / 1024} MB)`)
+    throw new ProcessImageError(
+      'file_too_large',
+      `image is too large; max ${MAX_BYTES / 1024 / 1024} MiB per file`,
+    )
   }
 
   const buffer = new Uint8Array(await file.arrayBuffer())

--- a/app/middleware/csrf-or-bearer.ts
+++ b/app/middleware/csrf-or-bearer.ts
@@ -2,15 +2,23 @@ import { csrf, type CsrfOptions } from 'remix/middleware/csrf'
 import type { Middleware } from 'remix/router'
 
 /**
- * Wraps the standard CSRF middleware so that requests to the JSON API surface
- * (`/api/*`) and requests carrying an `Authorization: Bearer ...` header skip
- * CSRF entirely. API clients authenticate with bearer tokens (not session
- * cookies), so the synchronizer token model doesn't apply to them — and they
- * have no way to read a token anyway. Auth failures inside the API return
- * 401 (handled by the controller), not a CSRF 403.
+ * Wraps the standard CSRF middleware so it short-circuits cleanly for
+ * requests that handle their own auth/CSRF posture:
  *
- * Inside the browser, session-cookie auth + form posts go through CSRF as
- * usual.
+ *  - `/api/*` routes: clients send `Authorization: Bearer ...`, not session
+ *    cookies, so the synchronizer-token model doesn't apply. Auth failures
+ *    return 401 from the controller rather than a 403 from CSRF.
+ *  - Requests with an `Authorization: Bearer` header anywhere on the site
+ *    (rare, but possible) similarly skip CSRF.
+ *  - `multipart/form-data` requests: the controller parses the body itself
+ *    via `readUploadFormData()` because the global form-data middleware
+ *    isn't allowed to consume it (it would throw on multipart limit errors
+ *    before the controller could render a friendly response). The
+ *    controller then re-verifies the `_csrf` field against the session
+ *    token using `assertCsrfToken()` from `app/utils/csrf.ts`.
+ *
+ * Everything else (the normal HTML form path) goes through the standard
+ * middleware unchanged.
  */
 export function csrfOrBearer(options?: CsrfOptions): Middleware {
   const csrfMiddleware = csrf(options)
@@ -21,6 +29,10 @@ export function csrfOrBearer(options?: CsrfOptions): Middleware {
     }
     const authHeader = context.request.headers.get('authorization') ?? ''
     if (/^Bearer\s+\S+/i.test(authHeader)) {
+      return next()
+    }
+    const contentType = context.request.headers.get('content-type') ?? ''
+    if (contentType.startsWith('multipart/form-data')) {
       return next()
     }
     return csrfMiddleware(context, next)

--- a/app/middleware/form-data.ts
+++ b/app/middleware/form-data.ts
@@ -1,0 +1,40 @@
+import { formData, type FormDataOptions } from 'remix/middleware/form-data'
+import type { Middleware } from 'remix/router'
+
+/**
+ * Wraps the standard `formData()` middleware so it does NOT eagerly parse
+ * `multipart/form-data` bodies. URL-encoded bodies (login, password change,
+ * invitations, etc.) are still parsed here as usual.
+ *
+ * Why: the upstream `formData()` middleware always rethrows multipart limit
+ * errors regardless of `suppressErrors`, which means a slightly-too-large
+ * upload bubbles up to the server entry point as a 500. The skill's
+ * documented pattern is to "catch domain-specific upload errors at the
+ * route boundary when they should become user-facing `Response` objects",
+ * so the four upload-handling controllers (sticker upload, sticker edit,
+ * avatar upload, API sticker create) call `readUploadFormData()`
+ * themselves and turn errors into proper responses with inline form
+ * messages or tagged JSON. See `app/utils/upload.ts`.
+ *
+ * Multipart-handling controllers must NOT call `context.get(FormData)` —
+ * use `readUploadFormData(context.request)` instead. They also need to
+ * call `assertCsrfToken(context, formData.get('_csrf'))` to validate the
+ * synchronizer token, since the CSRF middleware also skips multipart
+ * requests (it has no FormData to read from).
+ */
+export function formDataExceptUploads(
+  options?: FormDataOptions,
+): Middleware<{ key: typeof FormData; value: FormData; property: 'formData' }> {
+  const inner = formData(options)
+  return async (context, next) => {
+    const contentType = context.request.headers.get('content-type') ?? ''
+    if (contentType.startsWith('multipart/form-data')) {
+      // Don't touch the body — upload controllers will parse it themselves
+      // via `readUploadFormData()`. Anything that calls `get(FormData)` here
+      // will get undefined at runtime; the type assertion below documents
+      // the invariant that non-upload routes can read FormData freely.
+      return next()
+    }
+    return inner(context, next)
+  }
+}

--- a/app/router.ts
+++ b/app/router.ts
@@ -1,11 +1,26 @@
 import { createRouter, type MiddlewareContext } from 'remix/router'
 import { asyncContext } from 'remix/middleware/async-context'
 import { compression } from 'remix/middleware/compression'
-import { formData } from 'remix/middleware/form-data'
 import { logger } from 'remix/middleware/logger'
 import { staticFiles } from 'remix/middleware/static'
 
+import rootController from './actions/controller.tsx'
+import adminController from './actions/admin/controller.tsx'
+import apiController from './actions/api/controller.tsx'
+import changePasswordController from './actions/change-password/controller.tsx'
+import editProfileController from './actions/edit-profile/controller.tsx'
+import editStickerController from './actions/edit-sticker/controller.tsx'
+import invitationsController from './actions/invitations/controller.tsx'
+import invitationController from './actions/invitation/controller.tsx'
+import loginController from './actions/login/controller.tsx'
+import removeStickerController from './actions/remove-sticker/controller.tsx'
+import uploadStickerController from './actions/upload-sticker/controller.tsx'
+import { appSession, loadAuth } from './data/auth.ts'
+import { loadDatabase } from './middleware/database.ts'
+import { formDataExceptUploads } from './middleware/form-data.ts'
 import { csrfOrBearer } from './middleware/csrf-or-bearer.ts'
+import { render } from './middleware/render.tsx'
+import { routes } from './routes.ts'
 
 /**
  * Comma-separated list of allowed public origins for CSRF Origin/Referer checks.
@@ -26,26 +41,14 @@ function parsePublicOrigin(raw: string | undefined): string | string[] | undefin
   return list.length === 1 ? list[0] : list
 }
 
-import rootController from './actions/controller.tsx'
-import adminController from './actions/admin/controller.tsx'
-import apiController from './actions/api/controller.tsx'
-import changePasswordController from './actions/change-password/controller.tsx'
-import editProfileController from './actions/edit-profile/controller.tsx'
-import editStickerController from './actions/edit-sticker/controller.tsx'
-import invitationsController from './actions/invitations/controller.tsx'
-import invitationController from './actions/invitation/controller.tsx'
-import loginController from './actions/login/controller.tsx'
-import removeStickerController from './actions/remove-sticker/controller.tsx'
-import uploadStickerController from './actions/upload-sticker/controller.tsx'
-import { appSession, loadAuth } from './data/auth.ts'
-import { loadDatabase } from './middleware/database.ts'
-import { render } from './middleware/render.tsx'
-import { routes } from './routes.ts'
-
 const stack = [
   compression(),
   staticFiles('./public', { index: false }),
-  formData(),
+  // Parses application/x-www-form-urlencoded eagerly so simple forms
+  // (login, password, invitations) can use `get(FormData)` directly.
+  // Multipart bodies skip parsing here; upload-handling controllers parse
+  // them via `readUploadFormData()` so they can render inline errors.
+  formDataExceptUploads(),
   appSession(),
   csrfOrBearer({ origin: parsePublicOrigin(process.env.PUBLIC_ORIGIN) }),
   asyncContext(),

--- a/app/utils/csrf.ts
+++ b/app/utils/csrf.ts
@@ -1,0 +1,40 @@
+/**
+ * CSRF token check at the controller boundary.
+ *
+ * Used by upload-handling controllers whose multipart bodies are parsed by
+ * the controller itself instead of the global `formData()` middleware (see
+ * `app/utils/upload.ts`). The global CSRF middleware also skips multipart
+ * requests for the same reason, so each upload controller calls this after
+ * it parses its own `FormData`.
+ */
+import type { RequestContext } from 'remix/router'
+import { getCsrfToken } from 'remix/middleware/csrf'
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return mismatch === 0
+}
+
+/**
+ * Returns `null` when the submitted token matches the session-bound token,
+ * or a 403 `Response` when it doesn't. Controllers use the return value
+ * directly:
+ *
+ *   const denied = assertCsrfToken(context, formData.get('_csrf'))
+ *   if (denied) return denied
+ */
+export function assertCsrfToken(
+  context: RequestContext<any, any>,
+  submitted: FormDataEntryValue | null,
+): Response | null {
+  const expected = getCsrfToken(context)
+  const provided = typeof submitted === 'string' ? submitted.trim() : ''
+  if (provided === '' || !constantTimeEqual(provided, expected)) {
+    return new Response('Forbidden: invalid CSRF token', { status: 403 })
+  }
+  return null
+}

--- a/app/utils/upload.ts
+++ b/app/utils/upload.ts
@@ -1,0 +1,133 @@
+/**
+ * Boundary parsing for file-upload routes.
+ *
+ * The global `formData()` middleware unconditionally throws on multipart
+ * limit errors. For file-upload routes (sticker upload, sticker edit,
+ * avatar upload, API sticker create) we want the controller to translate
+ * those into a user-facing `Response` instead — that's the "return a
+ * `Response` for expected outcomes" pattern from the Remix skill.
+ *
+ * To do that, upload-handling controllers skip the global middleware and
+ * call `readUploadFormData(request)` here. The shape mirrors
+ * `parseSafe` from `remix/data-schema`: success returns `{ success: true,
+ * value }`, failure returns `{ success: false, error }` where `error`
+ * carries the HTTP status, a stable code, and a friendly message.
+ */
+import {
+  MaxFilesExceededError,
+  MaxFileSizeExceededError,
+  MaxHeaderSizeExceededError,
+  MaxPartsExceededError,
+  MaxTotalSizeExceededError,
+  MultipartParseError,
+  parseFormData,
+  type ParseFormDataOptions,
+} from '@remix-run/form-data-parser'
+
+/** Single source of truth for upload limits, kept simple on purpose. */
+export const UPLOAD_LIMITS = {
+  /** Max bytes per file. */
+  maxFileSize: 10 * 1024 * 1024,
+  /** Total request body cap (a little headroom over one file plus text fields). */
+  maxTotalSize: 11 * 1024 * 1024,
+  /** No reason a single sticker form should accept more than this. */
+  maxFiles: 4,
+  /** Plenty for fields plus a file or two. */
+  maxParts: 100,
+} as const satisfies ParseFormDataOptions
+
+/** Stable, machine-readable error codes. */
+export type UploadErrorCode =
+  | 'file_too_large'
+  | 'total_size_too_large'
+  | 'too_many_files'
+  | 'too_many_parts'
+  | 'header_too_large'
+  | 'malformed_upload'
+
+export interface UploadError {
+  status: number
+  code: UploadErrorCode
+  message: string
+  /** Extras returned alongside the code (e.g. `max_bytes`). */
+  extras: Record<string, unknown>
+}
+
+export type UploadResult =
+  | { success: true; value: FormData }
+  | { success: false; error: UploadError }
+
+function describeBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1) return `${Math.round(mb * 10) / 10} MiB`
+  return `${Math.round(bytes / 1024)} KiB`
+}
+
+function toUploadError(error: unknown): UploadError | null {
+  if (error instanceof MaxFileSizeExceededError) {
+    return {
+      status: 413,
+      code: 'file_too_large',
+      message: `image is too large; max ${describeBytes(UPLOAD_LIMITS.maxFileSize)} per file`,
+      extras: { max_bytes: UPLOAD_LIMITS.maxFileSize },
+    }
+  }
+  if (error instanceof MaxTotalSizeExceededError) {
+    return {
+      status: 413,
+      code: 'total_size_too_large',
+      message: `upload is too large overall; max ${describeBytes(UPLOAD_LIMITS.maxTotalSize)} per request`,
+      extras: { max_bytes: UPLOAD_LIMITS.maxTotalSize },
+    }
+  }
+  if (error instanceof MaxFilesExceededError) {
+    return {
+      status: 400,
+      code: 'too_many_files',
+      message: `too many files; max ${UPLOAD_LIMITS.maxFiles} per upload`,
+      extras: { max_files: UPLOAD_LIMITS.maxFiles },
+    }
+  }
+  if (error instanceof MaxPartsExceededError) {
+    return {
+      status: 400,
+      code: 'too_many_parts',
+      message: 'upload has too many fields',
+      extras: {},
+    }
+  }
+  if (error instanceof MaxHeaderSizeExceededError) {
+    return {
+      status: 400,
+      code: 'header_too_large',
+      message: 'upload contains an oversized header',
+      extras: {},
+    }
+  }
+  if (error instanceof MultipartParseError) {
+    return {
+      status: 400,
+      code: 'malformed_upload',
+      message: 'upload is malformed; please try again',
+      extras: {},
+    }
+  }
+  return null
+}
+
+/**
+ * Parse a multipart upload at the route boundary, turning multipart limit
+ * errors into a returned `UploadError` instead of a thrown exception. Any
+ * non-multipart error is rethrown so it surfaces as a real 500 — that's a
+ * bug to fix, not a user-facing condition.
+ */
+export async function readUploadFormData(request: Request): Promise<UploadResult> {
+  try {
+    const value = await parseFormData(request, UPLOAD_LIMITS)
+    return { success: true, value }
+  } catch (error) {
+    const uploadError = toUploadError(error)
+    if (uploadError) return { success: false, error: uploadError }
+    throw error
+  }
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,7 +9,6 @@ import { createMigrationRunner } from 'remix/data-table/migrations'
 import { loadMigrations } from 'remix/data-table/migrations/node'
 import { asyncContext } from 'remix/middleware/async-context'
 import { compression } from 'remix/middleware/compression'
-import { formData } from 'remix/middleware/form-data'
 import { staticFiles } from 'remix/middleware/static'
 import {
   auth,
@@ -19,6 +18,7 @@ import {
 import { session } from 'remix/middleware/session'
 
 import { csrfOrBearer } from '../app/middleware/csrf-or-bearer.ts'
+import { formDataExceptUploads } from '../app/middleware/form-data.ts'
 import { verifyToken } from '../app/data/api-tokens.ts'
 import { createCookie } from 'remix/cookie'
 import { createMemorySessionStorage } from 'remix/session-storage/memory'
@@ -115,7 +115,7 @@ export async function createTestEnv(options: CreateTestEnvOptions = {}): Promise
   const stack = [
     compression(),
     staticFiles('./public', { index: false }),
-    formData(),
+    formDataExceptUploads(),
     session(sessionCookie, sessionStorage),
     csrfOrBearer({ origin: options.publicOrigin }),
     asyncContext(),
@@ -177,15 +177,49 @@ export async function fetchCsrf(
 }
 
 /**
- * Send a POST with a same-origin Origin header. CSRF middleware checks origin
- * for cross-site protection; tests need to mimic a real browser submit.
+ * Send a POST as `application/x-www-form-urlencoded`, matching what a real
+ * browser sends for `<form method="post">` without `enctype="multipart/form-data"`.
+ * Use this for every non-file-upload form (login, change password, etc.).
  */
 export async function postForm(
   env: TestEnv,
   pathname: string,
-  options: { cookie?: string; body: FormData },
+  options: { cookie?: string; body: FormData | URLSearchParams | Record<string, string> },
 ): Promise<Response> {
-  const headers = new Headers({ origin: BASE })
+  const headers = new Headers({
+    origin: BASE,
+    'content-type': 'application/x-www-form-urlencoded',
+  })
+  if (options.cookie) headers.set('cookie', options.cookie)
+
+  let bodyString: string
+  if (options.body instanceof URLSearchParams) {
+    bodyString = options.body.toString()
+  } else if (options.body instanceof FormData) {
+    const params = new URLSearchParams()
+    for (const [key, value] of options.body.entries()) {
+      if (typeof value === 'string') params.append(key, value)
+    }
+    bodyString = params.toString()
+  } else {
+    bodyString = new URLSearchParams(options.body).toString()
+  }
+
+  return env.fetch(
+    new Request(buildUrl(pathname), { method: 'POST', headers, body: bodyString }),
+  )
+}
+
+/**
+ * Send a POST as `multipart/form-data`, matching what a real browser sends for
+ * `<form enctype="multipart/form-data">`. Use this for file-upload routes.
+ */
+export async function postMultipart(
+  env: TestEnv,
+  pathname: string,
+  options: { cookie?: string; headers?: Record<string, string>; body: FormData },
+): Promise<Response> {
+  const headers = new Headers({ origin: BASE, ...(options.headers ?? {}) })
   if (options.cookie) headers.set('cookie', options.cookie)
   return env.fetch(
     new Request(buildUrl(pathname), {
@@ -203,17 +237,10 @@ export async function loginAs(
 ): Promise<string> {
   // First, fetch /login to get a CSRF token + session cookie.
   const { token, cookie: preCookie } = await fetchCsrf(env, routes.login.index.href())
-  const body = new FormData()
-  body.set('_csrf', token)
-  body.set('username', username)
-  body.set('password', password)
-  const res = await env.fetch(
-    new Request(buildUrl(routes.login.action.href()), {
-      method: 'POST',
-      headers: { cookie: preCookie, origin: BASE },
-      body,
-    }),
-  )
+  const res = await postForm(env, routes.login.action.href(), {
+    cookie: preCookie,
+    body: { _csrf: token, username, password },
+  })
   if (res.status !== 303) {
     throw new Error(`Login failed: ${res.status} ${await res.text()}`)
   }

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -6,7 +6,14 @@ import bcrypt from 'bcryptjs'
 
 import { invitations, stickers, users, UserRoles } from '../app/data/schema.ts'
 import { routes } from '../app/routes.ts'
-import { buildUrl, createTestEnv, fetchCsrf, loginAs, postForm } from './helpers.ts'
+import {
+  buildUrl,
+  createTestEnv,
+  fetchCsrf,
+  loginAs,
+  postForm,
+  postMultipart,
+} from './helpers.ts'
 
 async function seedUser(
   env: Awaited<ReturnType<typeof createTestEnv>>,
@@ -66,12 +73,14 @@ describe('login', () => {
     const env = await createTestEnv()
     try {
       await seedUser(env, 'alice', 'goodpass')
-      const body = new FormData()
-      body.set('username', 'alice')
-      body.set('password', 'goodpass')
-      // No _csrf, no Origin header.
+      // No _csrf token, no Origin header. URL-encoded body so CSRF middleware
+      // actually runs (multipart bodies are handled by upload controllers).
       const res = await env.fetch(
-        new Request(buildUrl(routes.login.action.href()), { method: 'POST', body }),
+        new Request(buildUrl(routes.login.action.href()), {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: 'username=alice&password=goodpass',
+        }),
       )
       assert.equal(res.status, 403)
     } finally {
@@ -89,8 +98,11 @@ describe('login', () => {
       const res = await env.fetch(
         new Request(buildUrl(routes.login.action.href()), {
           method: 'POST',
-          headers: { origin: 'https://stickertrade.ca' },
-          body: new FormData(),
+          headers: {
+            origin: 'https://stickertrade.ca',
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          body: '',
         }),
       )
       assert.equal(res.status, 403)
@@ -112,8 +124,11 @@ describe('login', () => {
       const res = await env.fetch(
         new Request(buildUrl(routes.login.action.href()), {
           method: 'POST',
-          headers: { origin: 'https://stickertrade.ca' },
-          body: new FormData(),
+          headers: {
+            origin: 'https://stickertrade.ca',
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          body: '',
         }),
       )
       assert.equal(res.status, 403)
@@ -344,7 +359,7 @@ describe('edit profile', () => {
       const body = new FormData()
       body.set('_csrf', token)
       body.set('avatar', file)
-      const res = await postForm(env, routes.editProfile.action.href(), { cookie, body })
+      const res = await postMultipart(env, routes.editProfile.action.href(), { cookie, body })
       assert.equal(res.status, 303)
       assert.equal(res.headers.get('location'), routes.editProfile.index.href())
 
@@ -631,6 +646,73 @@ describe('api: stickers', () => {
     }
   })
 
+  it('POST /api/stickers rejects oversized files with a tagged JSON error', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'libby', 'libbypass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: userId }, 'tok')
+
+      // 11 MiB payload — exceeds the 10 MiB limit.
+      const huge = new Uint8Array(11 * 1024 * 1024)
+      const file = new File([huge], 'huge.png', { type: 'image/png' })
+
+      const body = new FormData()
+      body.set('name', 'too big')
+      body.set('image', file)
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerCreate.href()), {
+          method: 'POST',
+          headers: { authorization: `Bearer ${plaintext}` },
+          body,
+        }),
+      )
+      assert.equal(res.status, 413)
+      const payload = (await res.json()) as {
+        error: string
+        message: string
+        max_bytes: number
+      }
+      assert.equal(payload.error, 'file_too_large')
+      assert.match(payload.message, /max .* MiB/)
+      assert.equal(payload.max_bytes, 10 * 1024 * 1024)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('POST /api/stickers rejects unsupported image types', async () => {
+    const env = await createTestEnv()
+    try {
+      const userId = await seedUser(env, 'lana', 'lanapass')
+      const { createTokenForUser } = await import('../app/data/api-tokens.ts')
+      const { plaintext } = await createTokenForUser(env.db, { id: userId }, 'tok')
+
+      // A small file with a bogus type.
+      const small = new Uint8Array(100)
+      const file = new File([small], 'evil.gif', { type: 'image/gif' })
+
+      const body = new FormData()
+      body.set('name', 'no gifs')
+      body.set('image', file)
+
+      const res = await env.fetch(
+        new Request(buildUrl(routes.api.stickerCreate.href()), {
+          method: 'POST',
+          headers: { authorization: `Bearer ${plaintext}` },
+          body,
+        }),
+      )
+      assert.equal(res.status, 400)
+      const payload = (await res.json()) as { error: string; message: string }
+      assert.equal(payload.error, 'unsupported_image_type')
+      assert.match(payload.message, /png or jpeg/i)
+    } finally {
+      env.cleanup()
+    }
+  })
+
   it('PATCH /api/stickers/:id renames when owned', async () => {
     const env = await createTestEnv()
     try {
@@ -756,6 +838,37 @@ describe('api: stickers', () => {
         stickers: Array<{ name: string }>
       }
       assert.equal(stickersPayload.stickers[0]?.name, 'q1')
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
+describe('upload errors (html form)', () => {
+  it('POST /upload-sticker rejects oversized files with a friendly message', async () => {
+    const env = await createTestEnv()
+    try {
+      await seedUser(env, 'wendy', 'wendypass')
+      const sessionCookie = await loginAs(env, 'wendy', 'wendypass')
+      const { token, cookie } = await fetchCsrf(
+        env,
+        routes.uploadSticker.index.href(),
+        sessionCookie,
+      )
+
+      // 11 MiB payload — over the 10 MiB limit.
+      const huge = new Uint8Array(11 * 1024 * 1024)
+      const file = new File([huge], 'huge.png', { type: 'image/png' })
+
+      const body = new FormData()
+      body.set('_csrf', token)
+      body.set('name', 'too big')
+      body.set('image', file)
+
+      const res = await postMultipart(env, routes.uploadSticker.action.href(), { cookie, body })
+      assert.equal(res.status, 413)
+      const html = await res.text()
+      assert.match(html, /max .* MiB/)
     } finally {
       env.cleanup()
     }


### PR DESCRIPTION
## The bug

A user uploaded a file slightly over 2 MiB and got an opaque `Internal Server Error`. Root cause:

- `formData()` middleware uses a default `maxFileSize` of **2 MiB**.
- It unconditionally rethrows multipart limit errors (the upstream README says: "Multipart limit violations from `maxHeaderSize`, `maxFiles`, `maxFileSize`, `maxParts`, or `maxTotalSize` are never suppressed").
- Files between 2-10 MiB threw `MaxFileSizeExceededError` from middleware (before any controller ran) and bubbled to `server.ts` → 500.

## The first attempt (rejected on review)

I initially fixed this with a `handleRequest()` wrapper in server.ts that classified upload errors and returned proper responses globally. Reviewer correctly called this out as a code smell — it's bolt-on error handling at the wrong layer.

## The skill-aligned fix

Per the Remix skill: **"Catch domain-specific upload errors at the route boundary when they should become user-facing `Response` objects."**

That's exactly what the four upload-handling controllers now do. server.ts stays minimal.

### Middleware

- **`formDataExceptUploads()`** wraps the standard `formData()` middleware to skip multipart bodies entirely. URL-encoded forms (login, password, invitations) still flow through unchanged.
- **`csrfOrBearer()`** also skips multipart bodies (the CSRF middleware has no parsed FormData to read `_csrf` from). Upload controllers validate the token themselves after parsing.

### Controllers

Each upload-handling controller (upload-sticker, edit-sticker, edit-profile, api/stickerCreate):

```ts
const parsed = await readUploadFormData(context.request)
if (!parsed.success) {
  return context.render(
    <UploadStickerPage user={user} errors={{ image: parsed.error.message }} />,
    { status: parsed.error.status },
  )
}
const formData = parsed.value

const denied = assertCsrfToken(context, formData.get('_csrf'))
if (denied) return denied

// ...rest of action
```

The `readUploadFormData()` helper returns a `parseSafe`-style result: `{ success: true, value: FormData }` or `{ success: false, error: { status, code, message, extras } }`. Mirrors the pattern the skill recommends for `remix/data-schema`.

`edit-sticker` and `edit-profile` branch on content-type because both routes accept either multipart (with a new image) or url-encoded (rename only / remove-avatar only).

### Image-pipeline errors

`processImageUpload` now throws `ProcessImageError` with a stable `code` (`unsupported_image_type` or `file_too_large`) so controllers can return tagged JSON or render friendly messages for sharp-detected failures.

### New files

- `app/utils/upload.ts` — `UPLOAD_LIMITS`, `readUploadFormData`, `UploadError` types
- `app/utils/csrf.ts` — `assertCsrfToken`
- `app/middleware/form-data.ts` — `formDataExceptUploads`

### Removed

- `app/data/handle-request.ts` (server-level error wrapper, gone)
- `app/data/upload-errors.ts` (merged into `app/utils/upload.ts`)
- `app/data/upload-limits.ts` (merged into `app/utils/upload.ts`)
- `server.ts` reverted to its original minimal form

## Tests

35/35 passing.

- New helpers: `postForm` (url-encoded, like a normal browser form) and `postMultipart` (multipart, for upload forms). The shape of the test now matches what real browsers send.
- 3 new tests asserting the user-facing error paths: HTML 413 with inline message, API 413 tagged JSON with `max_bytes`, API 400 tagged JSON for unsupported types.

## Verified manually

| Path | Before | After |
|------|--------|-------|
| HTML 11 MiB sticker upload | 500 Internal Server Error | 413 with form re-rendered, inline error `image is too large; max 10 MiB per file` |
| API 11 MiB sticker upload | 500 Internal Server Error | 413 `{"error":"file_too_large","max_bytes":10485760,"message":"..."}` |
| API gif upload | 400 `{"error":"upload_failed"}` | 400 `{"error":"unsupported_image_type","message":"..."}` |
| Normal small upload | 303 redirect | 303 redirect (unchanged) |
| Login + change password + invitations | works | works (urlencoded path unchanged) |