### PR TITLE
audit followups: data-schema everywhere, combined upload helper, dead code, nits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,11 @@ request, components are not React.
 - Controllers return explicit `Response` objects (use `redirect(...)` or `context.render(...)`).
   Reserve thrown errors for genuinely unexpected failures.
 - Styling is `remix/ui` `css(...)` mixins; design tokens live in `app/ui/theme.ts`.
-- Auth checks are inline in controllers via `getCurrentUser(context)` / `requireAdmin(context)`
-  from `app/data/current-user.ts` (the admin controller centralises its check in an
-  `ensureAdmin` helper).
+- Auth checks are inline in controllers via `getCurrentUser(context)` from
+  `app/data/current-user.ts`. The unauth path returns a `Response` (redirect to login
+  or 401/403), never throws. The admin controller centralises its admin-or-401 check
+  in an `ensureAdmin` helper that returns `{ user, response }` — reuse that shape
+  if you add more admin-gated controllers.
 - File uploads go through `app/data/upload-sticker.ts`, which validates type/size and uses
   `sharp` to optimize images before persisting to `tmp/uploads/` via `remix/file-storage/fs`.
   The `uploads` route in the root controller serves them as a resource route.

--- a/app/actions/admin/admin-stickers-page.tsx
+++ b/app/actions/admin/admin-stickers-page.tsx
@@ -31,12 +31,14 @@ export function AdminStickersPage() {
         <div mix={headerStyle}>
           <p mix={css({ fontSize: '1.25rem', fontWeight: 600 })}>stickers (page {page})</p>
           <nav mix={css({ display: 'flex', gap: '0.5rem' })}>
-            <a
-              href={routes.admin.stickers.href() + `?page=${Math.max(0, page - 1)}`}
-              mix={navLinkStyle}
-            >
-              ← prev
-            </a>
+            {page > 0 ? (
+              <a
+                href={routes.admin.stickers.href() + `?page=${page - 1}`}
+                mix={navLinkStyle}
+              >
+                ← prev
+              </a>
+            ) : null}
             {hasNext ? (
               <a href={routes.admin.stickers.href() + `?page=${page + 1}`} mix={navLinkStyle}>
                 next →

--- a/app/actions/admin/admin-users-page.tsx
+++ b/app/actions/admin/admin-users-page.tsx
@@ -32,9 +32,11 @@ export function AdminUsersPage() {
         <div mix={headerStyle}>
           <p mix={css({ fontSize: '1.25rem', fontWeight: 600 })}>users (page {page})</p>
           <nav mix={css({ display: 'flex', gap: '0.5rem' })}>
-            <a href={routes.admin.users.href() + `?page=${Math.max(0, page - 1)}`} mix={navLinkStyle}>
-              ← prev
-            </a>
+            {page > 0 ? (
+              <a href={routes.admin.users.href() + `?page=${page - 1}`} mix={navLinkStyle}>
+                ← prev
+              </a>
+            ) : null}
             {hasNext ? (
               <a href={routes.admin.users.href() + `?page=${page + 1}`} mix={navLinkStyle}>
                 next →

--- a/app/actions/api/controller.tsx
+++ b/app/actions/api/controller.tsx
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { inList } from 'remix/data-table/operators'
 import { createController } from 'remix/router'
@@ -8,10 +10,18 @@ import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers, users } from '../../data/schema.ts'
 import { ProcessImageError, processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
+import { stickerNameSchema } from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { readUploadFormData } from '../../utils/upload.ts'
 import { jsonError, jsonOk } from './json.ts'
 import { serializeSticker, serializeUser, serializeUserStub } from './serializers.ts'
+
+const apiStickerCreateSchema = f.object({
+  name: f.field(stickerNameSchema),
+  image: f.file(
+    s.instanceof_(File).refine((file) => file.size > 0, 'Please attach an image'),
+  ),
+})
 
 const PAGE_SIZE = 50
 
@@ -86,30 +96,23 @@ export default createController(routes.api, {
       const user = getCurrentUser(context)
       if (!user) return jsonError(401, 'Unauthorized')
 
-      const parsed = await readUploadFormData(context.request)
-      if (!parsed.success) {
-        return jsonError(parsed.error.status, parsed.error.code, {
-          message: parsed.error.message,
-          ...parsed.error.extras,
+      const uploadParsed = await readUploadFormData(context.request)
+      if (!uploadParsed.success) {
+        return jsonError(uploadParsed.error.status, uploadParsed.error.code, {
+          message: uploadParsed.error.message,
+          ...uploadParsed.error.extras,
         })
       }
-      const formData = parsed.value
 
-      const name = String(formData.get('name') ?? '').trim()
-      const file = formData.get('image')
-
-      const issues: Array<{ path: string[]; message: string }> = []
-      if (name.length === 0 || name.length > 60) {
-        issues.push({ path: ['name'], message: 'Name must be 1-60 characters' })
+      const parsed = s.parseSafe(apiStickerCreateSchema, uploadParsed.value)
+      if (!parsed.success) {
+        return jsonError(400, 'Validation failed', { issues: parsed.issues })
       }
-      if (!(file instanceof File) || file.size === 0) {
-        issues.push({ path: ['image'], message: 'Please attach an image' })
-      }
-      if (issues.length > 0) return jsonError(400, 'Validation failed', { issues })
+      const { name, image } = parsed.value
 
       let storedImageUrl: string
       try {
-        storedImageUrl = await processStickerUpload(file as File)
+        storedImageUrl = await processStickerUpload(image)
       } catch (error) {
         if (error instanceof ProcessImageError) {
           const status = error.code === 'file_too_large' ? 413 : 400
@@ -148,25 +151,24 @@ export default createController(routes.api, {
       }
 
       // Accept either JSON ({"name": "..."}) or form-encoded body.
-      let payload: { name?: unknown }
+      let rawName: unknown
       const contentType = context.request.headers.get('content-type') ?? ''
       if (contentType.includes('application/json')) {
         try {
-          payload = (await context.request.json()) as { name?: unknown }
+          const payload = (await context.request.json()) as { name?: unknown }
+          rawName = payload.name
         } catch {
           return jsonError(400, 'Invalid JSON body')
         }
       } else {
-        const formData = context.get(FormData)
-        payload = { name: formData.get('name') }
+        rawName = context.get(FormData).get('name')
       }
 
-      const name = typeof payload.name === 'string' ? payload.name.trim() : ''
-      if (name.length === 0 || name.length > 60) {
-        return jsonError(400, 'Validation failed', {
-          issues: [{ path: ['name'], message: 'Name must be 1-60 characters' }],
-        })
+      const nameResult = s.parseSafe(stickerNameSchema, rawName)
+      if (!nameResult.success) {
+        return jsonError(400, 'Validation failed', { issues: nameResult.issues })
       }
+      const name = nameResult.value
 
       await db.update(stickers, sticker.id, { name, updated_at: Date.now() })
       const updated = await db.findOne(stickers, { where: { id: sticker.id } })

--- a/app/actions/api/controller.tsx
+++ b/app/actions/api/controller.tsx
@@ -221,5 +221,10 @@ export default createController(routes.api, {
         stickers: rows.map((s) => serializeSticker(s, u)),
       })
     },
+
+    // -------- Catch-all: any other /api/* URL --------
+    notFound() {
+      return jsonError(404, 'Not Found')
+    },
   },
 })

--- a/app/actions/change-password/controller.tsx
+++ b/app/actions/change-password/controller.tsx
@@ -1,3 +1,5 @@
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
@@ -6,8 +8,18 @@ import { createController } from 'remix/router'
 import { hashPassword, verifyPassword } from '../../data/auth.ts'
 import { getCurrentUser } from '../../data/current-user.ts'
 import { users } from '../../data/schema.ts'
+import {
+  issuesToFieldErrors,
+  newPasswordSchema,
+} from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { EditProfilePage } from '../edit-profile-page.tsx'
+
+const changePasswordSchema = f.object({
+  currentPassword: f.field(s.string()),
+  newPassword: f.field(newPasswordSchema),
+  confirmPassword: f.field(s.string()),
+})
 
 export default createController(routes.changePassword, {
   actions: {
@@ -22,23 +34,31 @@ export default createController(routes.changePassword, {
       if (!user) return redirect(routes.login.index.href(), 303)
 
       const formData = context.get(FormData)
-      const currentPassword = String(formData.get('currentPassword') ?? '')
-      const newPassword = String(formData.get('newPassword') ?? '')
-      const confirmPassword = String(formData.get('confirmPassword') ?? '')
+      const parsed = s.parseSafe(changePasswordSchema, formData)
+      const errors: Record<string, string> = parsed.success
+        ? {}
+        : issuesToFieldErrors(parsed.issues)
 
-      const errors: Record<string, string> = {}
-      if (newPassword.length < 8 || newPassword.length > 64) {
-        errors.newPassword = 'New password must be 8-64 characters'
-      }
-      if (newPassword !== confirmPassword) {
+      // Pull the raw fields even on parse failure for cross-field checks
+      // and for the password-verification step below.
+      const currentPassword = parsed.success
+        ? parsed.value.currentPassword
+        : String(formData.get('currentPassword') ?? '')
+      const newPassword = parsed.success
+        ? parsed.value.newPassword
+        : String(formData.get('newPassword') ?? '')
+      const confirmPassword = parsed.success
+        ? parsed.value.confirmPassword
+        : String(formData.get('confirmPassword') ?? '')
+
+      if (!errors.confirmPassword && newPassword !== confirmPassword) {
         errors.confirmPassword = "Passwords don't match"
       }
-      if (currentPassword === newPassword && !errors.newPassword) {
+      if (!errors.newPassword && currentPassword === newPassword) {
         errors.newPassword = 'New password must be different from current password'
       }
 
       const db = context.get(Database)
-
       if (Object.keys(errors).length === 0) {
         const row = await db.findOne(users, { where: { id: user.id } })
         if (!row || !(await verifyPassword(currentPassword, row.password_hash))) {

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -1,3 +1,4 @@
+import * as s from 'remix/data-schema'
 import { Database } from 'remix/data-table'
 import { inList } from 'remix/data-table/operators'
 import { Session } from 'remix/session'
@@ -12,6 +13,7 @@ import { getDevLog, getDevLogs } from '../data/dev-logs.ts'
 import { roadmapTasks } from '../data/roadmap.ts'
 import { apiTokens, stickers, users } from '../data/schema.ts'
 import { uploadStorage } from '../data/uploads.ts'
+import { tokenNameSchema } from '../data/validators.ts'
 import { routes } from '../routes.ts'
 import { BrandPage } from './brand-page.tsx'
 import { DevLogPage } from './dev-log-page.tsx'
@@ -205,14 +207,17 @@ export default createController(routes, {
       const user = getCurrentUser(context)
       if (!user) return redirect(routes.login.index.href(), 303)
       const formData = context.get(FormData)
-      const name = String(formData.get('name') ?? '').trim()
       const session = context.get(Session)
-      if (name.length === 0 || name.length > 60) {
-        session.flash('token_error_name', 'Token name must be 1-60 characters')
+      const parsed = s.parseSafe(tokenNameSchema, formData.get('name'))
+      if (!parsed.success) {
+        session.flash(
+          'token_error_name',
+          parsed.issues[0]?.message ?? 'Invalid token name',
+        )
         return redirect(routes.editProfile.index.href(), 303)
       }
       const db = context.get(Database)
-      const created = await createTokenForUser(db, user, name)
+      const created = await createTokenForUser(db, user, parsed.value)
       session.flash(
         'token_new',
         JSON.stringify({ name: created.name, plaintext: created.plaintext }),

--- a/app/actions/edit-profile/controller.tsx
+++ b/app/actions/edit-profile/controller.tsx
@@ -9,8 +9,7 @@ import { users } from '../../data/schema.ts'
 import { processAvatarUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
-import { assertCsrfToken } from '../../utils/csrf.ts'
-import { readUploadFormData } from '../../utils/upload.ts'
+import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { EditProfilePage } from '../edit-profile-page.tsx'
 
 async function safeRemoveStoredUpload(url: string | null) {
@@ -86,16 +85,15 @@ export default createController(routes.editProfile, {
 
       let formData: FormData
       if (isMultipart) {
-        const parsed = await readUploadFormData(context.request)
+        const parsed = await readVerifiedUploadFormData(context)
         if (!parsed.success) {
+          if (parsed.kind === 'csrf') return parsed.response
           return context.render(
             <EditProfilePage user={user} avatarErrors={{ avatar: parsed.error.message }} />,
             { status: parsed.error.status },
           )
         }
         formData = parsed.value
-        const denied = assertCsrfToken(context, formData.get('_csrf'))
-        if (denied) return denied
       } else {
         formData = context.get(FormData)
       }

--- a/app/actions/edit-profile/controller.tsx
+++ b/app/actions/edit-profile/controller.tsx
@@ -1,3 +1,5 @@
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
@@ -11,6 +13,12 @@ import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
 import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { EditProfilePage } from '../edit-profile-page.tsx'
+
+const avatarUploadSchema = f.object({
+  avatar: f.file(
+    s.instanceof_(File).refine((file) => file.size > 0, 'Please choose an image'),
+  ),
+})
 
 async function safeRemoveStoredUpload(url: string | null) {
   if (!url || !url.startsWith('/uploads/')) return
@@ -119,17 +127,20 @@ export default createController(routes.editProfile, {
       }
 
       // Upload avatar branch
-      const file = formData.get('avatar')
-      if (!(file instanceof File) || file.size === 0) {
+      const parsed = s.parseSafe(avatarUploadSchema, formData)
+      if (!parsed.success) {
         return context.render(
-          <EditProfilePage user={user} avatarErrors={{ avatar: 'Please choose an image' }} />,
+          <EditProfilePage
+            user={user}
+            avatarErrors={{ avatar: parsed.issues[0]?.message ?? 'Please choose an image' }}
+          />,
           { status: 400 },
         )
       }
 
       let storedUrl: string
       try {
-        storedUrl = await processAvatarUpload(file)
+        storedUrl = await processAvatarUpload(parsed.value.avatar)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Upload failed'
         return context.render(

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -8,8 +8,7 @@ import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import { routes } from '../../routes.ts'
-import { assertCsrfToken } from '../../utils/csrf.ts'
-import { readUploadFormData } from '../../utils/upload.ts'
+import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { EditStickerPage } from '../edit-sticker-page.tsx'
 
 function notFound() {
@@ -72,8 +71,9 @@ export default createController(routes.editSticker, {
 
       let formData: FormData
       if (isMultipart) {
-        const parsed = await readUploadFormData(context.request)
+        const parsed = await readVerifiedUploadFormData(context)
         if (!parsed.success) {
+          if (parsed.kind === 'csrf') return parsed.response
           return context.render(
             <EditStickerPage
               user={user}
@@ -84,8 +84,6 @@ export default createController(routes.editSticker, {
           )
         }
         formData = parsed.value
-        const denied = assertCsrfToken(context, formData.get('_csrf'))
-        if (denied) return denied
       } else {
         formData = context.get(FormData)
       }

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -1,3 +1,5 @@
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
@@ -7,9 +9,25 @@ import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
+import {
+  issuesToFieldErrors,
+  stickerNameSchema,
+} from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { EditStickerPage } from '../edit-sticker-page.tsx'
+
+// On the edit page the image field is optional — submitting without a file
+// keeps the existing image. We map any zero-byte File or absent field to
+// `undefined` so the action can branch on its presence cleanly.
+const optionalImage = s
+  .optional(s.instanceof_(File))
+  .transform((value) => (value && value.size > 0 ? value : undefined))
+
+const editStickerSchema = f.object({
+  name: f.field(stickerNameSchema),
+  image: f.file(optionalImage),
+})
 
 function notFound() {
   return new Response('Not Found', { status: 404 })
@@ -71,39 +89,32 @@ export default createController(routes.editSticker, {
 
       let formData: FormData
       if (isMultipart) {
-        const parsed = await readVerifiedUploadFormData(context)
-        if (!parsed.success) {
-          if (parsed.kind === 'csrf') return parsed.response
+        const verified = await readVerifiedUploadFormData(context)
+        if (!verified.success) {
+          if (verified.kind === 'csrf') return verified.response
           return context.render(
             <EditStickerPage
               user={user}
               sticker={{ id: sticker.id, name: sticker.name, image_url: sticker.image_url }}
-              errors={{ image: parsed.error.message }}
+              errors={{ image: verified.error.message }}
             />,
-            { status: parsed.error.status },
+            { status: verified.error.status },
           )
         }
-        formData = parsed.value
+        formData = verified.value
       } else {
         formData = context.get(FormData)
       }
 
-      const name = String(formData.get('name') ?? '').trim()
-      const file = formData.get('image')
-      const hasNewImage = file instanceof File && file.size > 0
-
-      const errors: Record<string, string> = {}
-      if (name.length === 0 || name.length > 60) {
-        errors.name = 'Name must be 1-60 characters'
-      }
-
-      if (Object.keys(errors).length > 0) {
+      const parsed = s.parseSafe(editStickerSchema, formData)
+      if (!parsed.success) {
+        const errors = issuesToFieldErrors(parsed.issues)
         return context.render(
           <EditStickerPage
             user={user}
             sticker={{
               id: sticker.id,
-              name,
+              name: String(formData.get('name') ?? ''),
               image_url: sticker.image_url,
             }}
             errors={errors}
@@ -112,15 +123,16 @@ export default createController(routes.editSticker, {
         )
       }
 
+      const { name, image } = parsed.value
       const changes: Partial<{ name: string; image_url: string; updated_at: number }> = {
         name,
         updated_at: Date.now(),
       }
 
-      if (hasNewImage) {
+      if (image) {
         let storedUrl: string
         try {
-          storedUrl = await processStickerUpload(file as File)
+          storedUrl = await processStickerUpload(image)
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Upload failed'
           return context.render(
@@ -138,7 +150,7 @@ export default createController(routes.editSticker, {
       await db.update(stickers, sticker.id, changes)
 
       // After the row is updated, clean up the previous file if it was replaced.
-      if (hasNewImage) {
+      if (image) {
         await safeRemoveStoredUpload(sticker.image_url)
       }
 

--- a/app/actions/invitation/controller.tsx
+++ b/app/actions/invitation/controller.tsx
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
@@ -8,9 +10,20 @@ import { createController } from 'remix/router'
 import { hashPassword } from '../../data/auth.ts'
 import { getCurrentUser } from '../../data/current-user.ts'
 import { invitations, users, UserRoles } from '../../data/schema.ts'
+import {
+  issuesToFieldErrors,
+  newPasswordSchema,
+  usernameSchema,
+} from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { formatRelative } from '../../utils/time.ts'
 import { InvitationPage } from '../invitation-page.tsx'
+
+const acceptInvitationSchema = f.object({
+  username: f.field(usernameSchema),
+  password: f.field(newPasswordSchema),
+  confirmPassword: f.field(s.string()),
+})
 
 function notFound() {
   return new Response('Not Found', { status: 404 })
@@ -45,16 +58,23 @@ export default createController(routes.invitation, {
 
     async action(context) {
       const formData = context.get(FormData)
-      const username = String(formData.get('username') ?? '').trim()
-      const password = String(formData.get('password') ?? '')
-      const confirmPassword = String(formData.get('confirmPassword') ?? '')
+      const parsed = s.parseSafe(acceptInvitationSchema, formData)
+      const errors: Record<string, string> = parsed.success
+        ? {}
+        : issuesToFieldErrors(parsed.issues)
+      const username = parsed.success
+        ? parsed.value.username
+        : String(formData.get('username') ?? '').trim()
+      const password = parsed.success
+        ? parsed.value.password
+        : String(formData.get('password') ?? '')
+      const confirmPassword = parsed.success
+        ? parsed.value.confirmPassword
+        : String(formData.get('confirmPassword') ?? '')
 
-      const errors: Record<string, string> = {}
-      if (username.length < 3 || username.length > 16)
-        errors.username = 'Username must be 3-16 characters'
-      if (password.length < 6 || password.length > 64)
-        errors.password = 'Password must be 6-64 characters'
-      if (password !== confirmPassword) errors.confirmPassword = "Passwords don't match"
+      if (!errors.confirmPassword && password !== confirmPassword) {
+        errors.confirmPassword = "Passwords don't match"
+      }
 
       const db = context.get(Database)
       const invitation = await db.findOne(invitations, { where: { id: context.params.id } })

--- a/app/actions/login/controller.tsx
+++ b/app/actions/login/controller.tsx
@@ -1,3 +1,5 @@
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { Session } from 'remix/session'
 import { redirect } from 'remix/response/redirect'
@@ -5,8 +7,18 @@ import { createController } from 'remix/router'
 
 import { verifyPassword } from '../../data/auth.ts'
 import { users } from '../../data/schema.ts'
+import {
+  issuesToFieldErrors,
+  loginPasswordSchema,
+  usernameSchema,
+} from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { LoginPage } from '../login-page.tsx'
+
+const loginSchema = f.object({
+  username: f.field(usernameSchema),
+  password: f.field(loginPasswordSchema),
+})
 
 export default createController(routes.login, {
   actions: {
@@ -19,20 +31,18 @@ export default createController(routes.login, {
 
     async action(context) {
       const formData = context.get(FormData)
-      const username = String(formData.get('username') ?? '').trim()
-      const password = String(formData.get('password') ?? '')
-
-      const errors: Record<string, string> = {}
-      if (username.length < 3 || username.length > 16) {
-        errors.username = 'Username must be 3-16 characters'
-      }
-      if (password.length < 6 || password.length > 64) {
-        errors.password = 'Password must be 6-64 characters'
-      }
-      if (Object.keys(errors).length > 0) {
-        return context.render(<LoginPage errors={errors} values={{ username }} />, { status: 400 })
+      const parsed = s.parseSafe(loginSchema, formData)
+      if (!parsed.success) {
+        return context.render(
+          <LoginPage
+            errors={issuesToFieldErrors(parsed.issues)}
+            values={{ username: String(formData.get('username') ?? '') }}
+          />,
+          { status: 400 },
+        )
       }
 
+      const { username, password } = parsed.value
       const db = context.get(Database)
       const user = await db.findOne(users, { where: { username } })
       if (!user || !(await verifyPassword(password, user.password_hash))) {

--- a/app/actions/upload-sticker/controller.tsx
+++ b/app/actions/upload-sticker/controller.tsx
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
+import * as s from 'remix/data-schema'
+import * as f from 'remix/data-schema/form-data'
 import { Database } from 'remix/data-table'
 import { redirect } from 'remix/response/redirect'
 import { createController } from 'remix/router'
@@ -7,9 +9,22 @@ import { createController } from 'remix/router'
 import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
+import {
+  issuesToFieldErrors,
+  stickerNameSchema,
+} from '../../data/validators.ts'
 import { routes } from '../../routes.ts'
 import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { UploadStickerPage } from '../upload-sticker-page.tsx'
+
+const fileRequired = s
+  .instanceof_(File)
+  .refine((file) => file.size > 0, 'Please choose an image')
+
+const uploadStickerSchema = f.object({
+  name: f.field(stickerNameSchema),
+  image: f.file(fileRequired),
+})
 
 export default createController(routes.uploadSticker, {
   actions: {
@@ -23,37 +38,33 @@ export default createController(routes.uploadSticker, {
       const user = getCurrentUser(context)
       if (!user) return redirect(routes.login.index.href(), 303)
 
-      const parsed = await readVerifiedUploadFormData(context)
-      if (!parsed.success) {
-        if (parsed.kind === 'csrf') return parsed.response
+      const verified = await readVerifiedUploadFormData(context)
+      if (!verified.success) {
+        if (verified.kind === 'csrf') return verified.response
         return context.render(
-          <UploadStickerPage user={user} errors={{ image: parsed.error.message }} />,
-          { status: parsed.error.status },
+          <UploadStickerPage user={user} errors={{ image: verified.error.message }} />,
+          { status: verified.error.status },
         )
       }
-      const formData = parsed.value
+      const formData = verified.value
 
-      const name = String(formData.get('name') ?? '').trim()
-      const file = formData.get('image')
-
-      const errors: Record<string, string> = {}
-      if (name.length === 0 || name.length > 60) {
-        errors.name = 'Name must be 1-60 characters'
-      }
-      if (!(file instanceof File) || file.size === 0) {
-        errors.image = 'Please choose an image'
-      }
-
-      if (Object.keys(errors).length > 0) {
+      const parsed = s.parseSafe(uploadStickerSchema, formData)
+      if (!parsed.success) {
         return context.render(
-          <UploadStickerPage user={user} errors={errors} values={{ name }} />,
+          <UploadStickerPage
+            user={user}
+            errors={issuesToFieldErrors(parsed.issues)}
+            values={{ name: String(formData.get('name') ?? '') }}
+          />,
           { status: 400 },
         )
       }
 
+      const { name, image } = parsed.value
+
       let storedImageUrl: string
       try {
-        storedImageUrl = await processStickerUpload(file as File)
+        storedImageUrl = await processStickerUpload(image)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Upload failed'
         return context.render(

--- a/app/actions/upload-sticker/controller.tsx
+++ b/app/actions/upload-sticker/controller.tsx
@@ -8,8 +8,7 @@ import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { routes } from '../../routes.ts'
-import { assertCsrfToken } from '../../utils/csrf.ts'
-import { readUploadFormData } from '../../utils/upload.ts'
+import { readVerifiedUploadFormData } from '../../utils/upload.ts'
 import { UploadStickerPage } from '../upload-sticker-page.tsx'
 
 export default createController(routes.uploadSticker, {
@@ -24,17 +23,15 @@ export default createController(routes.uploadSticker, {
       const user = getCurrentUser(context)
       if (!user) return redirect(routes.login.index.href(), 303)
 
-      const parsed = await readUploadFormData(context.request)
+      const parsed = await readVerifiedUploadFormData(context)
       if (!parsed.success) {
+        if (parsed.kind === 'csrf') return parsed.response
         return context.render(
           <UploadStickerPage user={user} errors={{ image: parsed.error.message }} />,
           { status: parsed.error.status },
         )
       }
       const formData = parsed.value
-
-      const denied = assertCsrfToken(context, formData.get('_csrf'))
-      if (denied) return denied
 
       const name = String(formData.get('name') ?? '').trim()
       const file = formData.get('image')

--- a/app/data/current-user.ts
+++ b/app/data/current-user.ts
@@ -11,20 +11,14 @@ interface AuthContext {
   get(key: typeof Auth): unknown
 }
 
+/**
+ * Read the authenticated user from request context, or `null` if the
+ * request is anonymous. Controllers branch on the return value and return
+ * a `Response` (redirect to login / 401 / etc.) for the unauth path —
+ * we don't throw for control flow per the Remix skill.
+ */
 export function getCurrentUser(context: AuthContext): AuthedUser | null {
   const auth = context.get(Auth) as { ok: boolean; identity?: AuthedUser } | undefined
   if (!auth || !auth.ok || !auth.identity) return null
   return auth.identity
-}
-
-export function requireCurrentUser(context: AuthContext): AuthedUser {
-  const user = getCurrentUser(context)
-  if (!user) throw new Response('Unauthorized', { status: 401 })
-  return user
-}
-
-export function requireAdmin(context: AuthContext): AuthedUser {
-  const user = requireCurrentUser(context)
-  if (user.role !== 'ADMIN') throw new Response('Forbidden', { status: 403 })
-  return user
 }

--- a/app/data/validators.ts
+++ b/app/data/validators.ts
@@ -1,0 +1,76 @@
+/**
+ * Reusable form-data validation building blocks.
+ *
+ * The codebase validates every form input via `remix/data-schema` + the
+ * `form-data` adapter; this module collects the shared sub-schemas
+ * (username, password, sticker name, etc.) so the rules live in one place
+ * and the same checks apply whether a field is submitted from the login
+ * form, the change-password form, an invitation accept, or the
+ * bootstrap-admin CLI.
+ *
+ * Controllers use these with `s.parseSafe(schema, formData)`. On failure
+ * they convert the resulting `issues[]` to a flat `{ field: message }`
+ * record via `issuesToFieldErrors` and re-render the page.
+ */
+import * as s from 'remix/data-schema'
+import type { Issue } from 'remix/data-schema'
+
+/**
+ * String with surrounding whitespace trimmed, then bounded in length with
+ * the supplied user-facing message.
+ */
+function boundedString(min: number, max: number, message: string) {
+  return s
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length >= min && value.length <= max, message)
+}
+
+/** Usernames are 3-16 chars, [a-zA-Z0-9_-]. Same rules everywhere. */
+export const usernameSchema = boundedString(3, 16, 'Username must be 3-16 characters').refine(
+  (value) => /^[a-zA-Z0-9_-]+$/.test(value),
+  'Username may only contain letters, numbers, underscores, and dashes',
+)
+
+/**
+ * Passwords are 8-64 chars. Used for setting NEW passwords (signup,
+ * change-password, bootstrap-admin). Login uses a looser schema since we
+ * don't want to leak the policy by rejecting a too-short submitted
+ * password — let bcrypt do its thing.
+ */
+export const newPasswordSchema = s
+  .string()
+  .refine((v) => v.length >= 8 && v.length <= 64, 'Password must be 8-64 characters')
+
+/** Login submits any non-empty string; verification happens against bcrypt. */
+export const loginPasswordSchema = s.string().refine((v) => v.length > 0, 'Password is required')
+
+/** Sticker names are 1-60 chars after trimming. */
+export const stickerNameSchema = boundedString(1, 60, 'Name must be 1-60 characters')
+
+/** Token labels mirror sticker names: 1-60 chars after trimming. */
+export const tokenNameSchema = boundedString(1, 60, 'Token name must be 1-60 characters')
+
+/**
+ * Flatten a `parseSafe` failure into a `{ fieldName: message }` record
+ * keyed by the first path segment. Multiple issues on the same field
+ * collapse to the first message — pages display one error per field, so
+ * piling them up doesn't help.
+ */
+export function issuesToFieldErrors(
+  issues: ReadonlyArray<Issue>,
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+  for (const issue of issues) {
+    const segments = issue.path
+    let key = '_form'
+    if (segments && segments.length > 0) {
+      const first = segments[0] as PropertyKey | { key?: PropertyKey }
+      key = String(
+        typeof first === 'object' && first !== null && 'key' in first ? first.key : first,
+      )
+    }
+    if (errors[key] == null) errors[key] = issue.message
+  }
+  return errors
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -67,5 +67,8 @@ export const routes = route({
     stickerDestroy: del('/stickers/:id'),
     userShow: get('/users/:username'),
     userStickers: get('/users/:username/stickers'),
+    // Catch-all for any other /api/* URL so unknown endpoints return a
+    // JSON 404 instead of the router's plain-text default.
+    notFound: '/*path',
   }),
 })

--- a/app/utils/upload.ts
+++ b/app/utils/upload.ts
@@ -22,7 +22,7 @@ import {
   MultipartParseError,
   parseFormData,
   type ParseFormDataOptions,
-} from '@remix-run/form-data-parser'
+} from 'remix/form-data-parser'
 
 /** Single source of truth for upload limits, kept simple on purpose. */
 export const UPLOAD_LIMITS = {

--- a/app/utils/upload.ts
+++ b/app/utils/upload.ts
@@ -8,11 +8,18 @@
  * `Response` for expected outcomes" pattern from the Remix skill.
  *
  * To do that, upload-handling controllers skip the global middleware and
- * call `readUploadFormData(request)` here. The shape mirrors
- * `parseSafe` from `remix/data-schema`: success returns `{ success: true,
- * value }`, failure returns `{ success: false, error }` where `error`
- * carries the HTTP status, a stable code, and a friendly message.
+ * call `readVerifiedUploadFormData(context)` here. That helper combines
+ * three steps into one: parse the multipart body, translate any limit
+ * error into a structured `UploadError`, and re-verify the `_csrf` field
+ * (since the global CSRF middleware also skips multipart bodies).
+ *
+ * The success shape mirrors `parseSafe` from `remix/data-schema`. Failure
+ * is a tagged union: `kind: 'upload'` carries the structured error info
+ * for controllers to turn into either an inline-error page (HTML) or a
+ * tagged JSON error (API), while `kind: 'csrf'` is already a `Response`
+ * the controller can return as-is.
  */
+import type { RequestContext } from 'remix/router'
 import {
   MaxFilesExceededError,
   MaxFileSizeExceededError,
@@ -23,6 +30,8 @@ import {
   parseFormData,
   type ParseFormDataOptions,
 } from 'remix/form-data-parser'
+
+import { assertCsrfToken } from './csrf.ts'
 
 /** Single source of truth for upload limits, kept simple on purpose. */
 export const UPLOAD_LIMITS = {
@@ -120,6 +129,9 @@ function toUploadError(error: unknown): UploadError | null {
  * errors into a returned `UploadError` instead of a thrown exception. Any
  * non-multipart error is rethrown so it surfaces as a real 500 — that's a
  * bug to fix, not a user-facing condition.
+ *
+ * Prefer `readVerifiedUploadFormData` in controllers — it folds in the
+ * CSRF check so callers can't forget either step.
  */
 export async function readUploadFormData(request: Request): Promise<UploadResult> {
   try {
@@ -130,4 +142,30 @@ export async function readUploadFormData(request: Request): Promise<UploadResult
     if (uploadError) return { success: false, error: uploadError }
     throw error
   }
+}
+
+export type VerifiedUploadResult =
+  | { success: true; value: FormData }
+  | { success: false; kind: 'upload'; error: UploadError }
+  | { success: false; kind: 'csrf'; response: Response }
+
+/**
+ * Parse the multipart body AND verify CSRF in one call. Controllers that
+ * accept browser uploads should reach for this — it eliminates the
+ * footgun of remembering to call both `readUploadFormData` and
+ * `assertCsrfToken`. API-only routes (which skip CSRF entirely) can
+ * still use `readUploadFormData` directly.
+ */
+export async function readVerifiedUploadFormData(
+  context: RequestContext<any, any>,
+): Promise<VerifiedUploadResult> {
+  const parsed = await readUploadFormData(context.request)
+  if (!parsed.success) {
+    return { success: false, kind: 'upload', error: parsed.error }
+  }
+  const denied = assertCsrfToken(context, parsed.value.get('_csrf'))
+  if (denied) {
+    return { success: false, kind: 'csrf', response: denied }
+  }
+  return { success: true, value: parsed.value }
 }

--- a/scripts/bootstrap-admin.ts
+++ b/scripts/bootstrap-admin.ts
@@ -2,9 +2,11 @@ import { randomUUID } from 'node:crypto'
 import { parseArgs } from 'node:util'
 
 import bcrypt from 'bcryptjs'
+import * as s from 'remix/data-schema'
 
 import { db } from '../app/data/db.ts'
 import { config, users, UserRoles } from '../app/data/schema.ts'
+import { newPasswordSchema, usernameSchema } from '../app/data/validators.ts'
 
 const USAGE = `Usage:
   bootstrap-admin --username <name> --password <password>
@@ -27,19 +29,6 @@ function fail(message: string): never {
   process.exit(1)
 }
 
-function validateUsername(value: string): string | null {
-  if (value.length < 3 || value.length > 16) return 'Username must be 3-16 characters'
-  if (!/^[a-zA-Z0-9_-]+$/.test(value))
-    return 'Username may only contain letters, numbers, underscores, and dashes'
-  return null
-}
-
-function validatePassword(value: string): string | null {
-  if (value.length < 8) return 'Password must be at least 8 characters'
-  if (value.length > 64) return 'Password must be 64 characters or fewer'
-  return null
-}
-
 async function ensureConfigRow(): Promise<void> {
   const existing = await db.findOne(config, { where: { id: 1 } })
   if (existing) return
@@ -60,17 +49,21 @@ if (values.help) {
   process.exit(0)
 }
 
-const username = values.username
-const password = values.password
+if (!values.username) fail('Missing required --username')
+if (!values.password) fail('Missing required --password')
 
-if (!username) fail('Missing required --username')
-if (!password) fail('Missing required --password')
+const usernameResult = s.parseSafe(usernameSchema, values.username)
+if (!usernameResult.success) {
+  fail(`Invalid --username: ${usernameResult.issues[0]?.message ?? 'invalid'}`)
+}
 
-const usernameError = validateUsername(username)
-if (usernameError) fail(`Invalid --username: ${usernameError}`)
+const passwordResult = s.parseSafe(newPasswordSchema, values.password)
+if (!passwordResult.success) {
+  fail(`Invalid --password: ${passwordResult.issues[0]?.message ?? 'invalid'}`)
+}
 
-const passwordError = validatePassword(password)
-if (passwordError) fail(`Invalid --password: ${passwordError}`)
+const username = usernameResult.value
+const password = passwordResult.value
 
 const existing = await db.findOne(users, { where: { username } })
 if (existing) fail(`User "${username}" already exists.`)

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -592,6 +592,19 @@ describe('api: stickers', () => {
     }
   })
 
+  it('GET /api/nonsense returns a JSON 404, not plaintext', async () => {
+    const env = await createTestEnv()
+    try {
+      const res = await env.fetch(new Request(buildUrl('/api/nonsense/path')))
+      assert.equal(res.status, 404)
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+      const payload = (await res.json()) as { error: string }
+      assert.equal(payload.error, 'Not Found')
+    } finally {
+      env.cleanup()
+    }
+  })
+
   it('POST /api/stickers requires bearer auth', async () => {
     const env = await createTestEnv()
     try {


### PR DESCRIPTION
Followup to a subagent audit of the codebase against the Remix 3 skill. Three logical commits, all touching different surfaces — review by commit if it's easier.

## Commit 1: dead code + subpath imports + admin pagination + JSON 404

Quick wins from the audit.

- **Delete `requireCurrentUser` and `requireAdmin` from `current-user.ts`** — unused (zero call sites), and they threw `Response` instead of returning, which the skill names as an anti-pattern. The admin controller has its own `ensureAdmin` helper that returns a `{user, response}` shape; `AGENTS.md` now describes that as the convention.
- **Switch `app/utils/upload.ts`** to import from `remix/form-data-parser` (documented subpath) instead of `@remix-run/form-data-parser` (transitive dep). Same exports, but the skill rule is "import from `remix/<subpath>`, never the scoped package."
- **Admin users / stickers pagination**: hide the `← prev` link when on page 0 instead of rendering a useless `?page=0` anchor.
- **JSON 404 for unknown `/api/*` URLs.** Added a catch-all `notFound` route + action so a typo'd API URL returns `{ "error": "Not Found" }` with `Content-Type: application/json`, not the router's default plaintext. Test included.

## Commit 2: fold CSRF check into the upload-parse helper

Three of the four upload controllers were calling `readUploadFormData` and then `assertCsrfToken` back-to-back. The two-step is a footgun: any new multipart route is one missed `assertCsrfToken` away from a CSRF bypass.

New `readVerifiedUploadFormData(context)` combines parse + CSRF check and returns a tagged result:
```ts
{ success: true; value: FormData }
{ success: false; kind: 'upload'; error: UploadError }
{ success: false; kind: 'csrf'; response: Response }
```

Controllers branch once on `kind`. The API `stickerCreate` stays on the lower-level `readUploadFormData` since `/api/*` skips CSRF entirely.

## Commit 3: `remix/data-schema` for input validation across all forms

Every form action in the codebase had been doing the exact pattern the skill names as an anti-pattern: raw `formData.get('name')` + manual length checks + an errors record. That loses the typed result and duplicates rules — password length was **6-64** in login + invitation but **8-64** in change-password + bootstrap-admin.

Now every action runs through `s.parseSafe(schema, formData)` and returns a `Response` with field errors on failure. Shared sub-schemas live in `app/data/validators.ts`:

| Schema | Rule |
|---|---|
| `usernameSchema` | 3-16 chars, `[a-zA-Z0-9_-]`, trimmed |
| `newPasswordSchema` | 8-64 chars (signup + change-password + bootstrap-admin) |
| `loginPasswordSchema` | ≥ 1 char (login keeps the loose rule so old short accounts can still authenticate; bcrypt does the work) |
| `stickerNameSchema` | 1-60 chars after trim |
| `tokenNameSchema` | 1-60 chars after trim |

`issuesToFieldErrors()` flattens the `parseSafe` issue array to the `{field: message}` shape pages already expect. Cross-field validation (newPassword ≠ confirmPassword, currentPassword ≠ newPassword) still lives inline since data-schema doesn't have a clean cross-field idiom.

Converted: login, change-password, invitation accept, upload-sticker, edit-sticker, edit-profile avatar, createApiToken, bootstrap-admin, api/stickerCreate, api/stickerUpdate. Password policy is now consistent at **8-64 for new passwords** everywhere.

## Verification

- `npm run typecheck` clean
- `npm test` 36/36 (no test changes needed — existing assertions match the new error messages)
- Manually smoke-tested: login (urlencoded), short password rejected with the right inline error, valid password change works, file upload too-large still returns inline error, normal upload still works, bootstrap-admin CLI validates correctly.

## Not addressed

A few items from the audit I deferred:

- **`as any` casts in `test/helpers.ts` and `router.ts`** — the auditor flagged that this suggests `MiddlewareContext<typeof stack>` isn't fully threaded. Typecheck is currently clean so it's not breaking; worth a separate look at some point.
- **`formDataExceptUploads` wrapper around the global `formData()` middleware** — auditor suggested this might collapse once upstream supports suppressing limit errors. Confirmed it still doesn't; keeping the wrapper for now.