### PR TITLE
sticker URLs: switch from UUID to slug

### DIFF
--- a/app/actions/admin/admin-stickers-page.tsx
+++ b/app/actions/admin/admin-stickers-page.tsx
@@ -8,6 +8,7 @@ import { colors } from '../../ui/theme.ts'
 
 export interface AdminStickerRow {
   id: string
+  slug: string
   name: string
   image_url: string
   owner: { username: string; avatar_url: string | null } | null
@@ -60,12 +61,12 @@ export function AdminStickersPage() {
             {stickers.map((s) => (
               <tr key={s.id}>
                 <td mix={cellStyle}>
-                  <a href={routes.sticker.href({ id: s.id })}>
+                  <a href={routes.sticker.href({ slug: s.slug })}>
                     <img src={s.image_url} alt={s.name} mix={previewStyle} />
                   </a>
                 </td>
                 <td mix={cellStyle}>
-                  <a href={routes.sticker.href({ id: s.id })} mix={css({ '&:hover': { textDecoration: 'underline' } })}>
+                  <a href={routes.sticker.href({ slug: s.slug })} mix={css({ '&:hover': { textDecoration: 'underline' } })}>
                     {s.name}
                   </a>
                 </td>

--- a/app/actions/admin/controller.tsx
+++ b/app/actions/admin/controller.tsx
@@ -101,6 +101,7 @@ export default createController(routes.admin, {
             const owner = s.owner_id ? ownerById.get(s.owner_id) ?? null : null
             return {
               id: s.id,
+              slug: s.slug,
               name: s.name,
               image_url: s.image_url,
               owner: owner ? { username: owner.username, avatar_url: owner.avatar_url ?? null } : null,

--- a/app/actions/api/serializers.ts
+++ b/app/actions/api/serializers.ts
@@ -3,6 +3,7 @@ import type { Sticker, User } from '../../data/schema.ts'
 export interface JsonSticker {
   id: string
   name: string
+  slug: string
   image_url: string
   owner: JsonUserStub | null
   created_at: number
@@ -41,6 +42,7 @@ export function serializeSticker(
   return {
     id: sticker.id,
     name: sticker.name,
+    slug: sticker.slug,
     image_url: sticker.image_url,
     owner: owner ? serializeUserStub(owner) : null,
     created_at: sticker.created_at,

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -12,6 +12,7 @@ import { buildDevLogsFeed } from '../data/dev-logs-feed.ts'
 import { getDevLog, getDevLogs } from '../data/dev-logs.ts'
 import { roadmapTasks } from '../data/roadmap.ts'
 import { apiTokens, stickers, users } from '../data/schema.ts'
+import { looksLikeUuid } from '../data/slug.ts'
 import { uploadStorage } from '../data/uploads.ts'
 import { tokenNameSchema } from '../data/validators.ts'
 import { routes } from '../routes.ts'
@@ -24,8 +25,6 @@ import { RoadmapPage } from './roadmap-page.tsx'
 import { StickerPage } from './sticker-page.tsx'
 import { StickersPage } from './stickers-page.tsx'
 import { UsersPage } from './users-page.tsx'
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function notFound(): Response {
   return new Response('Not Found', { status: 404 })
@@ -154,7 +153,7 @@ export default createController(routes, {
       const param = context.params.slug
 
       // Backwards compatibility: old UUID URLs 301-redirect to the slug URL.
-      if (UUID_REGEX.test(param)) {
+      if (looksLikeUuid(param)) {
         const byId = await db.findOne(stickers, { where: { id: param } })
         if (!byId) return notFound()
         return redirect(routes.sticker.href({ slug: byId.slug }), 301)

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -156,7 +156,7 @@ export default createController(routes, {
       if (looksLikeUuid(param)) {
         const byId = await db.findOne(stickers, { where: { id: param } })
         if (!byId) return notFound()
-        return redirect(routes.sticker.href({ slug: byId.slug }), 301)
+        return redirect(`/sticker/${encodeURIComponent(byId.slug)}`, 301)
       }
 
       const sticker = await db.findOne(stickers, { where: { slug: param } })

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -25,6 +25,8 @@ import { StickerPage } from './sticker-page.tsx'
 import { StickersPage } from './stickers-page.tsx'
 import { UsersPage } from './users-page.tsx'
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 function notFound(): Response {
   return new Response('Not Found', { status: 404 })
 }
@@ -73,6 +75,7 @@ export default createController(routes, {
           user={user}
           stickers={stickerRows.map((s) => ({
             id: s.id,
+            slug: s.slug,
             name: s.name,
             image_url: s.image_url,
             owner: s.owner_id
@@ -118,6 +121,7 @@ export default createController(routes, {
           user={getCurrentUser(context)}
           stickers={rows.map((s) => ({
             id: s.id,
+            slug: s.slug,
             name: s.name,
             image_url: s.image_url,
             owner: s.owner_id
@@ -147,7 +151,16 @@ export default createController(routes, {
     // -------- Sticker show --------
     async sticker(context) {
       const db = context.get(Database)
-      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      const param = context.params.slug
+
+      // Backwards compatibility: old UUID URLs 301-redirect to the slug URL.
+      if (UUID_REGEX.test(param)) {
+        const byId = await db.findOne(stickers, { where: { id: param } })
+        if (!byId) return notFound()
+        return redirect(routes.sticker.href({ slug: byId.slug }), 301)
+      }
+
+      const sticker = await db.findOne(stickers, { where: { slug: param } })
       if (!sticker) return notFound()
       let owner: { username: string; avatar_url: string | null } | null = null
       if (sticker.owner_id) {
@@ -159,6 +172,7 @@ export default createController(routes, {
           user={getCurrentUser(context)}
           sticker={{
             id: sticker.id,
+            slug: sticker.slug,
             name: sticker.name,
             image_url: sticker.image_url,
             owner,
@@ -186,6 +200,7 @@ export default createController(routes, {
             avatar_url: profileUser.avatar_url ?? null,
             stickers: profileStickers.map((s) => ({
               id: s.id,
+              slug: s.slug,
               name: s.name,
               image_url: s.image_url,
             })),

--- a/app/actions/edit-sticker-page.tsx
+++ b/app/actions/edit-sticker-page.tsx
@@ -15,7 +15,7 @@ import { colors } from '../ui/theme.ts'
 
 export interface EditStickerPageProps {
   user: HeaderUser
-  sticker: { id: string; name: string; image_url: string }
+  sticker: { id: string; slug: string; name: string; image_url: string }
   errors?: Record<string, string>
   flash?: string
 }
@@ -36,7 +36,7 @@ export function EditStickerPage() {
 
         <form
           method="post"
-          action={routes.editSticker.action.href({ id: sticker.id })}
+          action={routes.editSticker.action.href({ slug: sticker.slug })}
           encType="multipart/form-data"
         >
           <CsrfField />
@@ -48,7 +48,7 @@ export function EditStickerPage() {
           {errors._form ? <p mix={errorStyle}>{errors._form}</p> : null}
           <div mix={css({ display: 'flex', gap: '0.5rem', alignItems: 'center' })}>
             <SubmitButton label="save changes" />
-            <a href={routes.sticker.href({ id: sticker.id })} mix={cancelLinkStyle}>
+            <a href={routes.sticker.href({ slug: sticker.slug })} mix={cancelLinkStyle}>
               cancel
             </a>
           </div>

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -7,6 +7,7 @@ import { createController } from 'remix/router'
 
 import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
+import { looksLikeUuid } from '../../data/slug.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import { uploadStorage } from '../../data/uploads.ts'
 import {
@@ -28,8 +29,6 @@ const editStickerSchema = f.object({
   name: f.field(stickerNameSchema),
   image: f.file(optionalImage),
 })
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function notFound() {
   return new Response('Not Found', { status: 404 })
@@ -53,7 +52,7 @@ export default createController(routes.editSticker, {
 
       const db = context.get(Database)
       const param = context.params.slug
-      if (UUID_REGEX.test(param)) {
+      if (looksLikeUuid(param)) {
         const byId = await db.findOne(stickers, { where: { id: param } })
         if (!byId) return notFound()
         return redirect(routes.editSticker.index.href({ slug: byId.slug }), 301)

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -55,7 +55,7 @@ export default createController(routes.editSticker, {
       if (looksLikeUuid(param)) {
         const byId = await db.findOne(stickers, { where: { id: param } })
         if (!byId) return notFound()
-        return redirect(routes.editSticker.index.href({ slug: byId.slug }), 301)
+        return redirect(`/sticker/${encodeURIComponent(byId.slug)}/edit`, 301)
       }
       const sticker = await db.findOne(stickers, { where: { slug: param } })
       if (!sticker) return notFound()
@@ -181,7 +181,7 @@ export default createController(routes.editSticker, {
 
       const session = context.get(Session)
       session.flash('sticker_flash', 'Sticker updated.')
-      return redirect(routes.sticker.href({ slug: sticker.slug }), 303)
+      return redirect(`/sticker/${encodeURIComponent(sticker.slug)}`, 303)
     },
   },
 })

--- a/app/actions/edit-sticker/controller.tsx
+++ b/app/actions/edit-sticker/controller.tsx
@@ -29,6 +29,8 @@ const editStickerSchema = f.object({
   image: f.file(optionalImage),
 })
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 function notFound() {
   return new Response('Not Found', { status: 404 })
 }
@@ -50,7 +52,13 @@ export default createController(routes.editSticker, {
       if (!user) return redirect(routes.login.index.href(), 303)
 
       const db = context.get(Database)
-      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      const param = context.params.slug
+      if (UUID_REGEX.test(param)) {
+        const byId = await db.findOne(stickers, { where: { id: param } })
+        if (!byId) return notFound()
+        return redirect(routes.editSticker.index.href({ slug: byId.slug }), 301)
+      }
+      const sticker = await db.findOne(stickers, { where: { slug: param } })
       if (!sticker) return notFound()
       if (sticker.owner_id !== user.id && user.role !== 'ADMIN') {
         return new Response('Forbidden', { status: 403 })
@@ -63,7 +71,12 @@ export default createController(routes.editSticker, {
       return context.render(
         <EditStickerPage
           user={user}
-          sticker={{ id: sticker.id, name: sticker.name, image_url: sticker.image_url }}
+          sticker={{
+            id: sticker.id,
+            slug: sticker.slug,
+            name: sticker.name,
+            image_url: sticker.image_url,
+          }}
           flash={flash}
         />,
       )
@@ -74,7 +87,9 @@ export default createController(routes.editSticker, {
       if (!user) return redirect(routes.login.index.href(), 303)
 
       const db = context.get(Database)
-      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      // POST: look up by slug only. A POST to /sticker/<uuid>/edit is a
+      // stale form submission -- return 404 so the user re-navigates.
+      const sticker = await db.findOne(stickers, { where: { slug: context.params.slug } })
       if (!sticker) return notFound()
       if (sticker.owner_id !== user.id && user.role !== 'ADMIN') {
         return new Response('Forbidden', { status: 403 })
@@ -95,7 +110,12 @@ export default createController(routes.editSticker, {
           return context.render(
             <EditStickerPage
               user={user}
-              sticker={{ id: sticker.id, name: sticker.name, image_url: sticker.image_url }}
+              sticker={{
+                id: sticker.id,
+                slug: sticker.slug,
+                name: sticker.name,
+                image_url: sticker.image_url,
+              }}
               errors={{ image: verified.error.message }}
             />,
             { status: verified.error.status },
@@ -114,6 +134,7 @@ export default createController(routes.editSticker, {
             user={user}
             sticker={{
               id: sticker.id,
+              slug: sticker.slug,
               name: String(formData.get('name') ?? ''),
               image_url: sticker.image_url,
             }}
@@ -138,7 +159,12 @@ export default createController(routes.editSticker, {
           return context.render(
             <EditStickerPage
               user={user}
-              sticker={{ id: sticker.id, name, image_url: sticker.image_url }}
+              sticker={{
+                id: sticker.id,
+                slug: sticker.slug,
+                name,
+                image_url: sticker.image_url,
+              }}
               errors={{ image: message }}
             />,
             { status: 400 },
@@ -156,7 +182,7 @@ export default createController(routes.editSticker, {
 
       const session = context.get(Session)
       session.flash('sticker_flash', 'Sticker updated.')
-      return redirect(routes.sticker.href({ id: sticker.id }), 303)
+      return redirect(routes.sticker.href({ slug: sticker.slug }), 303)
     },
   },
 })

--- a/app/actions/profile-page.tsx
+++ b/app/actions/profile-page.tsx
@@ -12,7 +12,7 @@ export interface ProfilePageProps {
   profile: {
     username: string
     avatar_url: string | null
-    stickers: { id: string; name: string; image_url: string }[]
+    stickers: { id: string; slug: string; name: string; image_url: string }[]
   }
 }
 
@@ -55,7 +55,7 @@ export function ProfilePage() {
                 {isOwner ? (
                   <div mix={overlayStyle}>
                     <a
-                      href={routes.editSticker.index.href({ id: sticker.id })}
+                      href={routes.editSticker.index.href({ slug: sticker.slug })}
                       mix={editBtnStyle}
                       aria-label="edit sticker"
                     >

--- a/app/actions/sticker-page.tsx
+++ b/app/actions/sticker-page.tsx
@@ -10,6 +10,7 @@ export interface StickerPageProps {
   user: HeaderUser | null
   sticker: {
     id: string
+    slug: string
     name: string
     image_url: string
     owner: { username: string; avatar_url: string | null } | null
@@ -29,7 +30,7 @@ export function StickerPage() {
           title: sticker.name,
           description: `sticker ${ownerLabel}`,
           image: sticker.image_url,
-          url: routes.sticker.href({ id: sticker.id }),
+          url: routes.sticker.href({ slug: sticker.slug }),
           type: 'article',
         }}
       >
@@ -49,7 +50,7 @@ export function StickerPage() {
           ) : null}
           {canEdit ? (
             <div mix={css({ textAlign: 'center', marginTop: '1.25rem' })}>
-              <a href={routes.editSticker.index.href({ id: sticker.id })} mix={editLink}>
+              <a href={routes.editSticker.index.href({ slug: sticker.slug })} mix={editLink}>
                 edit this sticker
               </a>
             </div>

--- a/app/actions/upload-sticker/controller.tsx
+++ b/app/actions/upload-sticker/controller.tsx
@@ -8,6 +8,7 @@ import { createController } from 'remix/router'
 
 import { getCurrentUser } from '../../data/current-user.ts'
 import { stickers } from '../../data/schema.ts'
+import { generateStickerSlug } from '../../data/slug.ts'
 import { processStickerUpload } from '../../data/upload-image.ts'
 import {
   issuesToFieldErrors,
@@ -76,16 +77,18 @@ export default createController(routes.uploadSticker, {
       const db = context.get(Database)
       const now = Date.now()
       const id = randomUUID()
+      const slug = generateStickerSlug(name)
       await db.create(stickers, {
         id,
         name,
+        slug,
         image_url: storedImageUrl,
         owner_id: user.id,
         created_at: now,
         updated_at: now,
       })
 
-      return redirect(routes.sticker.href({ id }), 303)
+      return redirect(routes.sticker.href({ slug }), 303)
     },
   },
 })

--- a/app/actions/upload-sticker/controller.tsx
+++ b/app/actions/upload-sticker/controller.tsx
@@ -88,7 +88,7 @@ export default createController(routes.uploadSticker, {
         updated_at: now,
       })
 
-      return redirect(routes.sticker.href({ slug }), 303)
+      return redirect(`/sticker/${encodeURIComponent(slug)}`, 303)
     },
   },
 })

--- a/app/data/roadmap.ts
+++ b/app/data/roadmap.ts
@@ -80,6 +80,14 @@ const sourceTasks: Array<Omit<RoadmapTask, 'id'>> = [
 - [x] Per-user token management UI on /account/profile
 `),
   },
+  {
+    title: 'Slug URLs for stickers 🐌',
+    description: md(`
+- [x] Public sticker URLs are now \`/sticker/<name>-<6chars>\` instead of full UUIDs
+- [x] Old UUID URLs 301-redirect to the new slug URL
+- [x] JSON API and admin actions keep UUID params (intentional)
+`),
+  },
 
   // ---- Currently in focus ----
   {

--- a/app/data/schema.ts
+++ b/app/data/schema.ts
@@ -20,6 +20,7 @@ export const stickers = table({
   columns: {
     id: c.text().primaryKey(),
     name: c.text().notNull(),
+    slug: c.text().notNull().unique(),
     image_url: c.text().notNull(),
     owner_id: c.text(),
     created_at: c.integer().notNull(),

--- a/app/data/slug.ts
+++ b/app/data/slug.ts
@@ -33,6 +33,17 @@ export function generateStickerSlug(name: string): string {
   return slugPart === '' ? suffix : `${slugPart}-${suffix}`
 }
 
+/**
+ * True if the input string looks like a v4-ish UUID (8-4-4-4-12 lowercase
+ * hex). Used by the sticker show/edit handlers to detect old UUID URLs
+ * and 301-redirect them to the slug URL.
+ */
+export function looksLikeUuid(value: string): boolean {
+  return UUID_REGEX.test(value)
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 function randomSuffix(): string {
   // randomBytes(SUFFIX_LENGTH) gives us SUFFIX_LENGTH bytes of entropy;
   // we use each byte mod 36 to pick from the alphabet. The tiny bias

--- a/app/data/slug.ts
+++ b/app/data/slug.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from 'node:crypto'
+
+const SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
+const SUFFIX_LENGTH = 6
+const SLUG_PART_MAX = 40
+
+/**
+ * Reduce a sticker name to a URL-safe slug fragment.
+ *
+ * - Lowercases.
+ * - Replaces any run of non-`[a-z0-9]` chars with a single hyphen.
+ * - Trims leading/trailing hyphens.
+ * - Hard-caps at 40 chars (trimming any trailing hyphen left by the cut).
+ *
+ * Returns an empty string if the name slugifies to nothing (emoji-only
+ * names, whitespace-only names, etc.). Callers should append a suffix.
+ */
+export function slugifyName(name: string): string {
+  const lowered = name.toLowerCase()
+  const replaced = lowered.replace(/[^a-z0-9]+/g, '-')
+  const trimmed = replaced.replace(/^-+|-+$/g, '')
+  if (trimmed.length <= SLUG_PART_MAX) return trimmed
+  return trimmed.slice(0, SLUG_PART_MAX).replace(/-+$/g, '')
+}
+
+/**
+ * Build a full sticker slug: `<slug-part>-<6 lowercase alphanumerics>`.
+ * If `slugifyName(name)` is empty, returns just the 6-char suffix.
+ */
+export function generateStickerSlug(name: string): string {
+  const slugPart = slugifyName(name)
+  const suffix = randomSuffix()
+  return slugPart === '' ? suffix : `${slugPart}-${suffix}`
+}
+
+function randomSuffix(): string {
+  // randomBytes(SUFFIX_LENGTH) gives us SUFFIX_LENGTH bytes of entropy;
+  // we use each byte mod 36 to pick from the alphabet. The tiny bias
+  // (256 % 36 = 4 extra picks for the first 4 chars) does not matter
+  // for our use case.
+  const bytes = randomBytes(SUFFIX_LENGTH)
+  let out = ''
+  for (let i = 0; i < SUFFIX_LENGTH; i++) {
+    out += SUFFIX_ALPHABET[bytes[i]! % SUFFIX_ALPHABET.length]
+  }
+  return out
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,9 +13,9 @@ export const routes = route({
   stickers: '/stickers',
   users: '/users',
 
-  // Sticker show page
-  sticker: '/sticker/:id',
-  editSticker: form('/sticker/:id/edit'),
+  // Sticker show page (slug, not UUID)
+  sticker: '/sticker/:slug',
+  editSticker: form('/sticker/:slug/edit'),
 
   // Profile page
   profile: '/profile/:username',

--- a/app/ui/sticker-card.tsx
+++ b/app/ui/sticker-card.tsx
@@ -5,6 +5,7 @@ import { colors } from './theme.ts'
 
 export interface StickerCardSticker {
   id: string
+  slug: string
   name: string
   image_url: string
   owner?: {
@@ -22,7 +23,7 @@ export function StickerCard(handle: Handle<StickerCardProps>) {
   return () => {
     const { sticker, showOwner = true } = handle.props
     return (
-      <a href={routes.sticker.href({ id: sticker.id })} mix={cardStyle}>
+      <a href={routes.sticker.href({ slug: sticker.slug })} mix={cardStyle}>
         <div mix={imageWrapStyle}>
           <img src={sticker.image_url} alt={sticker.name} mix={imageStyle} />
         </div>

--- a/docs/superpowers/plans/2026-06-03-sticker-slugs.md
+++ b/docs/superpowers/plans/2026-06-03-sticker-slugs.md
@@ -1,0 +1,1009 @@
+# Sticker Slugs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace UUID-based public sticker URLs (`/sticker/<uuid>`) with name-derived slug URLs (`/sticker/dino-sticker-k3p9aq`), with a 301 redirect from the old form for backwards compatibility.
+
+**Architecture:** Add a `slug` column to the `stickers` table (one SQL migration that adds the column, backfills name-derived slugs for existing rows, and creates a unique index). Route contract changes from `:id` to `:slug`. Show/edit controllers look up by slug, with a UUID-shaped param redirected to the slug URL. All form action endpoints, the JSON API, and admin routes keep their UUID params unchanged.
+
+**Tech Stack:** Remix 3, `remix/data-table` (SQLite via `node:sqlite`), pure-SQL migrations via `remix/data-table/migrations/node`, `node:crypto` for the random suffix, `node:test` for tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-sticker-slugs-design.md`
+
+**Working branch:** `sticker-slugs` (already checked out)
+
+---
+
+## File Structure
+
+**Create:**
+- `app/data/slug.ts` — pure-function `slugifyName` and `generateStickerSlug`
+- `app/data/slug.test.ts` — unit tests for the above
+- `migrations/20260603000000_add_sticker_slug/up.sql` — schema change + backfill + unique index
+- `migrations/20260603000000_add_sticker_slug/down.sql` — drop index + drop column
+- `test/migrations.test.ts` — end-to-end backfill test
+
+**Modify:**
+- `app/data/schema.ts` — add `slug` column to `stickers` table definition
+- `app/routes.ts` — change `:id` to `:slug` for `sticker` and `editSticker`
+- `app/actions/controller.tsx` — sticker show: look up by slug, redirect from UUID
+- `app/actions/edit-sticker/controller.tsx` — edit GET + POST: look up by slug, redirect from UUID on GET
+- `app/actions/upload-sticker/controller.tsx` — generate slug on create, redirect to slug URL
+- `app/ui/sticker-card.tsx` — link by slug
+- `app/actions/admin/admin-stickers-page.tsx` — link by slug
+- `app/actions/sticker-page.tsx` — OG canonical URL uses slug
+- `app/actions/edit-sticker-page.tsx` — cancel link uses slug
+- `test/smoke.test.ts` — existing edit-sticker tests use slug; add new tests for redirect + 404
+- `app/data/roadmap.ts` — add roadmap entry under "Recently shipped"
+
+**Do NOT modify** (intentionally — these keep UUID params):
+- `app/actions/api/controller.tsx` (JSON API)
+- `app/actions/admin/controller.tsx` (admin delete routes)
+- `app/actions/remove-sticker/controller.tsx` (form POST target)
+- `app/actions/invitations/controller.tsx`, `invitation/controller.tsx`
+- The `removeSticker`, `createApiToken`, `revokeApiToken`, admin routes in `app/routes.ts`
+
+---
+
+## Task 1: Pure-function slug helpers
+
+**Files:**
+- Create: `app/data/slug.ts`
+- Test: `app/data/slug.test.ts`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+Create `app/data/slug.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { generateStickerSlug, slugifyName } from './slug.ts'
+
+describe('slugifyName', () => {
+  it('lowercases and hyphenates spaces', () => {
+    assert.equal(slugifyName('Dino Sticker'), 'dino-sticker')
+  })
+
+  it('strips non-alphanumeric chars and collapses runs of hyphens', () => {
+    assert.equal(slugifyName('coffee & code'), 'coffee-code')
+    assert.equal(slugifyName('foo!!!bar???baz'), 'foo-bar-baz')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    assert.equal(slugifyName('---hello---'), 'hello')
+    assert.equal(slugifyName('   spaced   '), 'spaced')
+  })
+
+  it('returns an empty string for all-non-ASCII names', () => {
+    assert.equal(slugifyName('🦖'), '')
+    assert.equal(slugifyName('🦖 🔥 🦖'), '')
+  })
+
+  it('caps at 40 chars and re-trims trailing hyphen left by the cut', () => {
+    const longName = 'a'.repeat(200)
+    assert.equal(slugifyName(longName), 'a'.repeat(40))
+    const oddCut = 'a'.repeat(39) + ' ' + 'b'.repeat(50)
+    // 'aaaa...aaa-bbbb...' — first 40 chars is 39 a's + '-' which trims to 39 a's
+    assert.equal(slugifyName(oddCut), 'a'.repeat(39))
+  })
+})
+
+describe('generateStickerSlug', () => {
+  it('produces <slug-part>-<6 lowercase alphanumerics>', () => {
+    const slug = generateStickerSlug('Dino Sticker')
+    assert.match(slug, /^dino-sticker-[a-z0-9]{6}$/)
+  })
+
+  it('produces just the suffix when the name slugifies to empty', () => {
+    const slug = generateStickerSlug('🦖')
+    assert.match(slug, /^[a-z0-9]{6}$/)
+  })
+
+  it('produces different suffixes across calls', () => {
+    const a = generateStickerSlug('test')
+    const b = generateStickerSlug('test')
+    assert.notEqual(a, b)
+  })
+})
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `npm test -- --test-name-pattern='slugify|generateStickerSlug'`
+
+Expected: FAIL — `app/data/slug.ts` does not exist.
+
+- [ ] **Step 1.3: Implement `app/data/slug.ts`**
+
+Create `app/data/slug.ts`:
+
+```ts
+import { randomBytes } from 'node:crypto'
+
+const SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
+const SUFFIX_LENGTH = 6
+const SLUG_PART_MAX = 40
+
+/**
+ * Reduce a sticker name to a URL-safe slug fragment.
+ *
+ * - Lowercases.
+ * - Replaces any run of non-`[a-z0-9]` chars with a single hyphen.
+ * - Trims leading/trailing hyphens.
+ * - Hard-caps at 40 chars (trimming any trailing hyphen left by the cut).
+ *
+ * Returns an empty string if the name slugifies to nothing (emoji-only
+ * names, whitespace-only names, etc.). Callers should append a suffix.
+ */
+export function slugifyName(name: string): string {
+  const lowered = name.toLowerCase()
+  const replaced = lowered.replace(/[^a-z0-9]+/g, '-')
+  const trimmed = replaced.replace(/^-+|-+$/g, '')
+  if (trimmed.length <= SLUG_PART_MAX) return trimmed
+  return trimmed.slice(0, SLUG_PART_MAX).replace(/-+$/g, '')
+}
+
+/**
+ * Build a full sticker slug: `<slug-part>-<6 lowercase alphanumerics>`.
+ * If `slugifyName(name)` is empty, returns just the 6-char suffix.
+ */
+export function generateStickerSlug(name: string): string {
+  const slugPart = slugifyName(name)
+  const suffix = randomSuffix()
+  return slugPart === '' ? suffix : `${slugPart}-${suffix}`
+}
+
+function randomSuffix(): string {
+  // randomBytes(SUFFIX_LENGTH) gives us SUFFIX_LENGTH bytes of entropy;
+  // we use each byte mod 36 to pick from the alphabet. The tiny bias
+  // (256 % 36 = 4 extra picks for the first 4 chars) does not matter
+  // for our use case.
+  const bytes = randomBytes(SUFFIX_LENGTH)
+  let out = ''
+  for (let i = 0; i < SUFFIX_LENGTH; i++) {
+    out += SUFFIX_ALPHABET[bytes[i]! % SUFFIX_ALPHABET.length]
+  }
+  return out
+}
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern='slugify|generateStickerSlug'`
+
+Expected: PASS, all 8 assertions.
+
+- [ ] **Step 1.5: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add app/data/slug.ts app/data/slug.test.ts
+git commit -m "add slug helpers + tests"
+```
+
+---
+
+## Task 2: Schema, migration, migration test
+
+**Files:**
+- Modify: `app/data/schema.ts`
+- Create: `migrations/20260603000000_add_sticker_slug/up.sql`
+- Create: `migrations/20260603000000_add_sticker_slug/down.sql`
+- Create: `test/migrations.test.ts`
+
+- [ ] **Step 2.1: Add `slug` column to the table definition**
+
+Edit `app/data/schema.ts`. Find the `stickers` table (around lines 18-28) and add `slug`:
+
+```ts
+export const stickers = table({
+  name: 'stickers',
+  columns: {
+    id: c.text().primaryKey(),
+    name: c.text().notNull(),
+    slug: c.text().notNull().unique(),
+    image_url: c.text().notNull(),
+    owner_id: c.text(),
+    created_at: c.integer().notNull(),
+    updated_at: c.integer().notNull(),
+  },
+})
+```
+
+- [ ] **Step 2.2: Create migration up SQL**
+
+Create `migrations/20260603000000_add_sticker_slug/up.sql`:
+
+```sql
+ALTER TABLE stickers ADD COLUMN slug TEXT NOT NULL DEFAULT '';
+
+-- Backfill: lowercase the name, replace common separators with hyphens,
+-- trim edge hyphens, append a random 6-char hex suffix.
+-- This is the "good enough" SQL version of slugifyName -- it handles
+-- common cases (spaces, basic punctuation) but does not strip every
+-- non-alphanumeric the way the TS function does. Acceptable: this only
+-- runs once against existing rows; new stickers go through the TS helper.
+UPDATE stickers
+SET slug = trim(
+  replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(
+    lower(name),
+    ' ', '-'), '_', '-'), '.', '-'), ',', '-'), '!', '-'),
+    '?', '-'), ':', '-'), ';', '-'), '/', '-'), '\', '-'),
+  '-'
+) || '-' || lower(hex(randomblob(3)))
+WHERE slug = '';
+
+-- Strip rows that ended up with a leading '-' (name was all separators
+-- on the left). The suffix still keeps them unique.
+UPDATE stickers SET slug = substr(slug, 2) WHERE slug LIKE '-%';
+
+CREATE UNIQUE INDEX stickers_slug_unique ON stickers(slug);
+```
+
+- [ ] **Step 2.3: Create migration down SQL**
+
+Create `migrations/20260603000000_add_sticker_slug/down.sql`:
+
+```sql
+DROP INDEX stickers_slug_unique;
+ALTER TABLE stickers DROP COLUMN slug;
+```
+
+- [ ] **Step 2.4: Write the failing migration test**
+
+Create `test/migrations.test.ts`:
+
+```ts
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { DatabaseSync } from 'node:sqlite'
+import { createDatabase } from 'remix/data-table'
+import { createSqliteDatabaseAdapter } from 'remix/data-table/sqlite'
+import { createMigrationRunner } from 'remix/data-table/migrations'
+import { loadMigrations } from 'remix/data-table/migrations/node'
+
+import { stickers } from '../app/data/schema.ts'
+
+const SLUG_MIGRATION_ID = '20260603000000'
+
+describe('add_sticker_slug migration', () => {
+  it('backfills name-derived slugs and enforces uniqueness', async () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'stickertrade-mig-test-'))
+    const dbPath = path.join(tmpDir, 'mig.sqlite')
+    const sqlite = new DatabaseSync(dbPath)
+    sqlite.exec('PRAGMA foreign_keys = ON')
+
+    try {
+      const adapter = createSqliteDatabaseAdapter(sqlite)
+      const db = createDatabase(adapter)
+      const allMigrations = await loadMigrations('./migrations')
+
+      // Find the migration immediately before the slug one and run up to it.
+      const slugIdx = allMigrations.findIndex((m) => m.id === SLUG_MIGRATION_ID)
+      assert.ok(slugIdx > 0, 'slug migration must exist with previous migrations applied')
+      const previousId = allMigrations[slugIdx - 1]!.id
+
+      const runner = createMigrationRunner(adapter, allMigrations)
+      await runner.up({ to: previousId })
+
+      // Insert stickers using raw SQL because the schema in code already
+      // has the slug column, but at this point in time the DB does not.
+      const now = Date.now()
+      const insert = sqlite.prepare(
+        'INSERT INTO stickers (id, name, image_url, owner_id, created_at, updated_at) VALUES (?, ?, ?, NULL, ?, ?)',
+      )
+      const fixtures = [
+        { id: randomUUID(), name: 'Dino Sticker', expect: /^dino-sticker-[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: 'hello', expect: /^hello-[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: '!!!', expect: /^[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: '🦖', expect: /^🦖-[0-9a-f]{6}$/ },
+      ]
+      for (const f of fixtures) {
+        insert.run(f.id, f.name, '/uploads/test.png', now, now)
+      }
+
+      // Now apply the slug migration. The backfill UPDATE runs inside it.
+      await runner.up({ to: SLUG_MIGRATION_ID })
+
+      // Each sticker should now have a slug matching its expected pattern.
+      const slugs: string[] = []
+      for (const f of fixtures) {
+        const row = await db.findOne(stickers, { where: { id: f.id } })
+        assert.ok(row, `sticker ${f.name} not found`)
+        assert.match(row.slug, f.expect, `slug for ${JSON.stringify(f.name)} = ${JSON.stringify(row.slug)}`)
+        slugs.push(row.slug)
+      }
+
+      // All slugs unique.
+      assert.equal(new Set(slugs).size, slugs.length, 'slugs should be unique')
+
+      // The unique index rejects duplicates.
+      const dupId = randomUUID()
+      assert.throws(
+        () => {
+          sqlite
+            .prepare(
+              'INSERT INTO stickers (id, name, slug, image_url, owner_id, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?)',
+            )
+            .run(dupId, 'dup', slugs[0]!, '/uploads/x.png', now, now)
+        },
+        /UNIQUE/,
+      )
+    } finally {
+      sqlite.close()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})
+```
+
+- [ ] **Step 2.5: Run the migration test to verify it fails**
+
+Run: `npm test -- --test-name-pattern='add_sticker_slug migration'`
+
+Expected: FAIL — the migration directory does not exist yet, or the assertion against the backfill pattern fails. (If the previous steps were done in order, the migration files exist; the test should pass. If the test fails because of a path/ordering issue, debug here before continuing.)
+
+- [ ] **Step 2.6: Run all tests to confirm migration test passes and nothing else regressed**
+
+Run: `npm test`
+
+Expected: existing 36 tests still pass, plus the new migration test and the slug helper tests. **Note:** some smoke tests will start failing here because the schema now requires a non-empty `slug` for new inserts. This is expected and fixed in Task 3+. Read the failures and confirm they are all sticker-insert related, not regressions from the migration logic itself.
+
+- [ ] **Step 2.7: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add app/data/schema.ts migrations/20260603000000_add_sticker_slug/ test/migrations.test.ts
+git commit -m "add sticker.slug column + backfill migration + test"
+```
+
+---
+
+## Task 3: Route contract change
+
+**Files:**
+- Modify: `app/routes.ts`
+
+- [ ] **Step 3.1: Change param from `:id` to `:slug` for sticker routes**
+
+Edit `app/routes.ts`. Find lines 16-18 (the sticker routes):
+
+```ts
+  // Sticker show page
+  sticker: '/sticker/:id',
+  editSticker: form('/sticker/:id/edit'),
+```
+
+Change to:
+
+```ts
+  // Sticker show page (slug, not UUID)
+  sticker: '/sticker/:slug',
+  editSticker: form('/sticker/:slug/edit'),
+```
+
+- [ ] **Step 3.2: Run typecheck to see every call site that needs to change**
+
+Run: `npm run typecheck`
+
+Expected: FAIL with errors like `Property 'id' is missing in type '{ slug: ... }'` or `Property 'slug' is missing in type '{ id: ... }'` at every site that calls `routes.sticker.href({ id: ... })` or reads `context.params.id` inside the sticker controllers.
+
+The next tasks fix these sites one by one.
+
+- [ ] **Step 3.3: Commit (just the routes change — broken state is intentional, fixed in subsequent tasks)**
+
+Actually, **do NOT commit yet.** This task leaves the tree in a state where typecheck fails. Commit at the end of Task 4 along with all the call-site updates, so the tree compiles between commits.
+
+---
+
+## Task 4: Controller and view call-site updates
+
+**Files:**
+- Modify: `app/actions/controller.tsx`
+- Modify: `app/actions/edit-sticker/controller.tsx`
+- Modify: `app/actions/upload-sticker/controller.tsx`
+- Modify: `app/ui/sticker-card.tsx`
+- Modify: `app/actions/admin/admin-stickers-page.tsx`
+- Modify: `app/actions/sticker-page.tsx`
+- Modify: `app/actions/edit-sticker-page.tsx`
+
+The `sticker-page.tsx` and `sticker-card.tsx` etc. all receive sticker objects from controllers. We need to thread the `slug` through everywhere the `id` was used to build URLs. The simplest approach: keep `id` for internal references (admin delete, remove-sticker form action) and add `slug` for the show/edit URLs.
+
+- [ ] **Step 4.1: Update root controller sticker show**
+
+Edit `app/actions/controller.tsx`. Find the `sticker` action (around line 148):
+
+Replace:
+
+```ts
+    // -------- Sticker show --------
+    async sticker(context) {
+      const db = context.get(Database)
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return notFound()
+```
+
+With:
+
+```ts
+    // -------- Sticker show --------
+    async sticker(context) {
+      const db = context.get(Database)
+      const param = context.params.slug
+
+      // Backwards compatibility: old UUID URLs 301-redirect to the slug URL.
+      if (UUID_REGEX.test(param)) {
+        const byId = await db.findOne(stickers, { where: { id: param } })
+        if (!byId) return notFound()
+        return redirect(routes.sticker.href({ slug: byId.slug }), 301)
+      }
+
+      const sticker = await db.findOne(stickers, { where: { slug: param } })
+      if (!sticker) return notFound()
+```
+
+You'll also need a `UUID_REGEX` constant. Add it near the top of the file (after the imports):
+
+```ts
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+```
+
+If `redirect` is not already imported in this file, import it from `remix/response/redirect`.
+
+Verify by reading the file: the `sticker` action should now look up by slug, redirect UUIDs, and the surrounding code (passing `sticker` to `<StickerPage />`) is unchanged.
+
+- [ ] **Step 4.2: Update edit-sticker controller (GET + POST)**
+
+Edit `app/actions/edit-sticker/controller.tsx`. In the `index` action (around line 53):
+
+Replace:
+
+```ts
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return notFound()
+```
+
+With:
+
+```ts
+      const param = context.params.slug
+      if (UUID_REGEX.test(param)) {
+        const byId = await db.findOne(stickers, { where: { id: param } })
+        if (!byId) return notFound()
+        return redirect(routes.editSticker.index.href({ slug: byId.slug }), 301)
+      }
+      const sticker = await db.findOne(stickers, { where: { slug: param } })
+      if (!sticker) return notFound()
+```
+
+In the `action` action (around line 77), the POST handler:
+
+Replace:
+
+```ts
+      const sticker = await db.findOne(stickers, { where: { id: context.params.id } })
+      if (!sticker) return notFound()
+```
+
+With:
+
+```ts
+      // POST: look up by slug only. A POST to /sticker/<uuid>/edit is a
+      // stale form submission — return 404 so the user re-navigates.
+      const sticker = await db.findOne(stickers, { where: { slug: context.params.slug } })
+      if (!sticker) return notFound()
+```
+
+Add the UUID_REGEX constant near the top of the file (after imports):
+
+```ts
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+```
+
+Find the final redirect line (around line 159):
+
+Replace:
+
+```ts
+      return redirect(routes.sticker.href({ id: sticker.id }), 303)
+```
+
+With:
+
+```ts
+      return redirect(routes.sticker.href({ slug: sticker.slug }), 303)
+```
+
+- [ ] **Step 4.3: Update upload-sticker controller**
+
+Edit `app/actions/upload-sticker/controller.tsx`.
+
+Import the slug helper. Add to the imports at the top:
+
+```ts
+import { generateStickerSlug } from '../../data/slug.ts'
+```
+
+In the `action` function, find the block that creates a sticker (around line 77-86):
+
+Replace:
+
+```ts
+      const db = context.get(Database)
+      const now = Date.now()
+      const id = randomUUID()
+      await db.create(stickers, {
+        id,
+        name,
+        image_url: storedImageUrl,
+        owner_id: user.id,
+        created_at: now,
+        updated_at: now,
+      })
+
+      return redirect(routes.sticker.href({ id }), 303)
+```
+
+With:
+
+```ts
+      const db = context.get(Database)
+      const now = Date.now()
+      const id = randomUUID()
+      const slug = generateStickerSlug(name)
+      await db.create(stickers, {
+        id,
+        name,
+        slug,
+        image_url: storedImageUrl,
+        owner_id: user.id,
+        created_at: now,
+        updated_at: now,
+      })
+
+      return redirect(routes.sticker.href({ slug }), 303)
+```
+
+- [ ] **Step 4.4: Update `sticker-card.tsx`**
+
+Edit `app/ui/sticker-card.tsx`. The card takes a sticker prop and links by id. Find around line 25:
+
+```ts
+      <a href={routes.sticker.href({ id: sticker.id })} mix={cardStyle}>
+```
+
+Change to:
+
+```ts
+      <a href={routes.sticker.href({ slug: sticker.slug })} mix={cardStyle}>
+```
+
+The TypeScript type for the sticker prop is defined in this file (or imported). Open the file fully to find the prop type. If the type is `{ id: string; name: string; image_url: string }`, change it to include `slug: string`. If `id` is only used for the URL, you can drop it from the prop shape entirely — but it's safer to keep both since other components may pass id-bearing objects. **Keep `id` in the prop shape, add `slug`.**
+
+- [ ] **Step 4.5: Update `admin-stickers-page.tsx`**
+
+Edit `app/actions/admin/admin-stickers-page.tsx`. Find both occurrences (lines 63 and 68):
+
+```ts
+                  <a href={routes.sticker.href({ id: s.id })}>
+                  ...
+                  <a href={routes.sticker.href({ id: s.id })} mix={css({ '&:hover': { textDecoration: 'underline' } })}>
+```
+
+Change both to:
+
+```ts
+                  <a href={routes.sticker.href({ slug: s.slug })}>
+                  ...
+                  <a href={routes.sticker.href({ slug: s.slug })} mix={css({ '&:hover': { textDecoration: 'underline' } })}>
+```
+
+The page receives `s` (a sticker row) from the admin controller, which queries the `stickers` table. Since the table now has `slug`, `s.slug` is available. Check the page's prop type — add `slug: string` to the row shape if needed.
+
+- [ ] **Step 4.6: Update `sticker-page.tsx`**
+
+Edit `app/actions/sticker-page.tsx`. Find around line 32:
+
+```ts
+          url: routes.sticker.href({ id: sticker.id }),
+```
+
+Change to:
+
+```ts
+          url: routes.sticker.href({ slug: sticker.slug }),
+```
+
+Update the sticker prop type in this file to include `slug: string`. Also: the root controller passes `sticker: { id, name, image_url, owner }` into this page (look at controller.tsx lines 159-166). Update that to pass `slug` as well:
+
+In `app/actions/controller.tsx` `sticker` action (around line 160):
+
+```ts
+          sticker={{
+            id: sticker.id,
+            slug: sticker.slug,
+            name: sticker.name,
+            image_url: sticker.image_url,
+            owner,
+          }}
+```
+
+- [ ] **Step 4.7: Update `edit-sticker-page.tsx`**
+
+Edit `app/actions/edit-sticker-page.tsx`. Find around line 51:
+
+```ts
+            <a href={routes.sticker.href({ id: sticker.id })} mix={cancelLinkStyle}>
+```
+
+Change to:
+
+```ts
+            <a href={routes.sticker.href({ slug: sticker.slug })} mix={cancelLinkStyle}>
+```
+
+Update the `sticker` prop type to include `slug: string`. Then update the edit-sticker controller's render call (in `app/actions/edit-sticker/controller.tsx`, around line 64-66) to pass `slug`:
+
+```ts
+        <EditStickerPage
+          user={user}
+          sticker={{ id: sticker.id, slug: sticker.slug, name: sticker.name, image_url: sticker.image_url }}
+          flash={flash}
+        />,
+```
+
+Do the same for any other `EditStickerPage` renderings inside the controller's error branches (lines ~96-100, ~115-119, ~140-141).
+
+- [ ] **Step 4.8: Update profile page sticker cards if they pass sticker data**
+
+Check `app/actions/profile-page.tsx` or wherever stickers are passed to `<StickerCard />`. The profile controller (in `app/actions/controller.tsx` around line 187) maps stickers like `s => ({ id: s.id, name: s.name, ... })`. Update that mapping to include `slug: s.slug`. Apply the same change anywhere `stickers.map` returns objects fed into `<StickerCard />`.
+
+Specifically check:
+- `app/actions/controller.tsx` `profile` action (line ~187)
+- Home page (`app/actions/home-page.tsx` and its controller call sites)
+- Stickers index (`app/actions/stickers-page.tsx` and its controller call site)
+
+For each: add `slug: s.slug` to the mapped object, and update the receiving page's prop type to include it.
+
+- [ ] **Step 4.9: Update seed script**
+
+Edit `scripts/seed.ts`. The seed creates a sample sticker. Find the sticker insert and add a slug field. Use `generateStickerSlug` from `app/data/slug.ts`:
+
+Add the import:
+
+```ts
+import { generateStickerSlug } from '../app/data/slug.ts'
+```
+
+Find the `db.create(stickers, { ... })` call and add:
+
+```ts
+slug: generateStickerSlug(name),
+```
+
+(where `name` is whatever the sample sticker's name variable is — check the file).
+
+- [ ] **Step 4.10: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean. If errors remain, fix them — each error points to a call site that still uses `id` where it now needs `slug`, or a prop type that doesn't include `slug`. Read the error, fix the site, re-run.
+
+- [ ] **Step 4.11: Commit the routes change + all call-site updates together**
+
+```bash
+git add app/routes.ts app/actions/ app/ui/sticker-card.tsx scripts/seed.ts
+git commit -m "switch sticker URLs from UUID to slug"
+```
+
+---
+
+## Task 5: Update smoke tests
+
+**Files:**
+- Modify: `test/smoke.test.ts`
+
+The two existing tests that reference `routes.sticker.href({ id: stickerId })` need to use the slug. Since the test creates stickers via `env.db.create(stickers, {...})` directly, the test must now also supply a `slug` field.
+
+- [ ] **Step 5.1: Generate slugs in existing test fixtures**
+
+Edit `test/smoke.test.ts`. Find all `env.db.create(stickers, { ... })` calls. For each, add a `slug` field using `generateStickerSlug` from `app/data/slug.ts`.
+
+Add the import at the top of the test file:
+
+```ts
+import { generateStickerSlug } from '../app/data/slug.ts'
+```
+
+Then for each `env.db.create(stickers, { ... })` call (lines 258-260, 403-411, 442-446, 561-563, 735-737, 770-772, and any others ripgrep finds), add `slug: generateStickerSlug(<name>)` to the object literal.
+
+Example (line ~404):
+
+```ts
+      const stickerId = randomUUID()
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: 'old name',
+        slug: generateStickerSlug('old name'),
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+```
+
+- [ ] **Step 5.2: Update existing `routes.sticker.href` and `routes.editSticker.*.href` calls in tests**
+
+Find every test call that references `routes.sticker.href({ id: stickerId })` or `routes.editSticker.{index,action}.href({ id: stickerId })`. To use the new slug URL, the test needs the slug. The cleanest pattern: store the slug in a local variable when constructing the fixture, then use it in URLs.
+
+For each test that creates a sticker and then makes URL references, refactor like so:
+
+```ts
+      const stickerId = randomUUID()
+      const stickerName = 'old name'
+      const stickerSlug = generateStickerSlug(stickerName)
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: stickerName,
+        slug: stickerSlug,
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      // ... later, where the test was using id:
+      const res = await postForm(env, routes.editSticker.action.href({ slug: stickerSlug }), { ... })
+      assert.equal(res.headers.get('location'), routes.sticker.href({ slug: stickerSlug }))
+```
+
+Apply this pattern at each test site identified in Step 5.1. **Do not** change the `routes.admin.deleteSticker.href({ id: ... })` call (line ~272) or any `routes.api.*` calls — those still use UUID by design.
+
+- [ ] **Step 5.3: Add the UUID → slug redirect test**
+
+In `test/smoke.test.ts`, find the `describe('edit sticker', ...)` block or any other sticker-related `describe`. Add a new top-level `describe('sticker URL backwards compatibility', () => { ... })` block. Inside:
+
+```ts
+describe('sticker URL backwards compatibility', () => {
+  it('301-redirects /sticker/<uuid> to the slug URL', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'redirector', 'redirectorpass')
+      const stickerId = randomUUID()
+      const stickerName = 'Vintage'
+      const stickerSlug = generateStickerSlug(stickerName)
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: stickerName,
+        slug: stickerSlug,
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(
+        new Request(buildUrl(`/sticker/${stickerId}`), { redirect: 'manual' }),
+      )
+      assert.equal(res.status, 301)
+      assert.equal(res.headers.get('location'), `/sticker/${stickerSlug}`)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('returns 404 for a /sticker/<uuid> with no matching sticker', async () => {
+    const env = await createTestEnv()
+    try {
+      const phantomId = randomUUID()
+      const res = await env.fetch(new Request(buildUrl(`/sticker/${phantomId}`)))
+      assert.equal(res.status, 404)
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+```
+
+- [ ] **Step 5.4: Run all tests**
+
+Run: `npm test`
+
+Expected: all tests pass (existing 36 + new migration test + new redirect tests + slug helper tests).
+
+If any sticker-related test fails because of a missing `slug` field, you missed a `db.create(stickers, ...)` call in Step 5.1 — search for it and fix.
+
+- [ ] **Step 5.5: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add test/smoke.test.ts
+git commit -m "tests: use slug URLs + add UUID-redirect coverage"
+```
+
+---
+
+## Task 6: Browser verification
+
+**Files:** none modified; manual verification.
+
+- [ ] **Step 6.1: Start dev server**
+
+Run (in a separate terminal or background):
+
+```bash
+SESSION_SECRET=dev-secret npm run dev
+```
+
+Wait for "listening on http://localhost:3000" or equivalent.
+
+- [ ] **Step 6.2: Verify new uploads get slug URLs**
+
+1. Visit http://localhost:3000/login
+2. Log in as `alice` / `alicepass` (from seed)
+3. Visit /upload-sticker
+4. Upload a sticker named "Test Slug"
+5. After redirect, verify the URL is `/sticker/test-slug-<6chars>` (where the 6 chars match `[a-z0-9]`)
+
+- [ ] **Step 6.3: Verify UUID URL redirects**
+
+1. Find an existing sticker's UUID (look in the seed data or copy from an admin page). Or, take note of the new sticker's UUID by querying via the API: `curl http://localhost:3000/api/stickers/<slug>` won't help (that's slug); instead, log in as admin and visit `/admin/stickers` — the IDs aren't visible there. Easier: query the DB directly via `sqlite3 db/stickertrade.sqlite "SELECT id, slug FROM stickers LIMIT 1"`.
+2. Visit `http://localhost:3000/sticker/<the-uuid>` in the browser. The URL bar should change to `/sticker/<the-slug>` after the redirect.
+3. Confirm the network panel shows a 301.
+
+- [ ] **Step 6.4: Verify rename does NOT change the URL**
+
+1. Visit `/sticker/<some-slug>` and click "edit" (only visible to the owner).
+2. Rename the sticker.
+3. After redirect, the URL is still the original slug (not regenerated from the new name). This confirms frozen-slug behaviour.
+
+- [ ] **Step 6.5: Verify emoji-only name produces suffix-only URL**
+
+1. Upload a sticker named just `🦖`.
+2. Verify the URL is `/sticker/<6chars>` (no slug-part, just suffix).
+
+- [ ] **Step 6.6: Stop dev server**
+
+If running in background:
+
+```bash
+# find and kill it
+```
+
+(Or just Ctrl-C in the foreground terminal.)
+
+---
+
+## Task 7: Roadmap update
+
+**Files:**
+- Modify: `app/data/roadmap.ts`
+
+- [ ] **Step 7.1: Add roadmap entry**
+
+Edit `app/data/roadmap.ts`. Find the "Recently shipped" section (the early items in `sourceTasks`). Add a new entry, in the same style as the existing ones:
+
+```ts
+  {
+    title: 'Slug URLs for stickers 🐌',
+    description: md(`
+- [x] Public sticker URLs are now \`/sticker/<name>-<6chars>\` instead of full UUIDs
+- [x] Old UUID URLs 301-redirect to the new slug URL
+- [x] JSON API and admin actions keep UUID params (intentional)
+`),
+  },
+```
+
+Place it after the "JSON API 🔌" entry and before the "Opengraph images 🖼️" entry.
+
+- [ ] **Step 7.2: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean.
+
+- [ ] **Step 7.3: Run tests**
+
+Run: `npm test`
+
+Expected: all pass.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add app/data/roadmap.ts
+git commit -m "roadmap: mark sticker slugs shipped"
+```
+
+---
+
+## Task 8: Open PR
+
+- [ ] **Step 8.1: Push the branch**
+
+```bash
+git push -u origin sticker-slugs
+```
+
+- [ ] **Step 8.2: Open the PR**
+
+Use `gh` to open the PR against `main`:
+
+```bash
+gh pr create \
+  --base main \
+  --head sticker-slugs \
+  --title "sticker URLs: switch from UUID to slug" \
+  --body "$(cat <<'EOF'
+Replace UUID-based sticker URLs with name-derived slugs.
+
+`/sticker/5a2077e8-ef49-446b-aa27-dca99e15a9b4` → `/sticker/dino-sticker-k3p9aq`
+
+## What changed
+
+- New `slug` column on the `stickers` table, backfilled in a single SQL migration.
+- `app/data/slug.ts` provides `slugifyName` and `generateStickerSlug`. Pure functions, fully unit-tested.
+- Route contract: `/sticker/:id` → `/sticker/:slug`, same for the edit page.
+- Old UUID URLs 301-redirect to the slug URL.
+- Slug is frozen at sticker creation. Renaming does not regenerate.
+
+## What did NOT change
+
+- JSON API still uses UUID (`/api/stickers/:id`).
+- All form action / POST targets still use UUID (admin delete, remove-sticker, etc.).
+- Invitations still use UUID (security-sensitive).
+
+## Verification
+
+- 36 existing tests still pass.
+- New tests: slug helper unit tests, migration backfill test, UUID-redirect smoke tests.
+- Manual browser verification: new uploads get slug URLs; UUID URLs redirect; rename does not change slug; emoji names get suffix-only URLs.
+
+Spec: `docs/superpowers/specs/2026-06-03-sticker-slugs-design.md`
+Plan: `docs/superpowers/plans/2026-06-03-sticker-slugs.md`
+EOF
+)"
+```
+
+- [ ] **Step 8.3: Report the PR URL to the user**
+
+Print the PR URL (the `gh pr create` command outputs it on success). Note that the user prefers to review before merging — do not merge.
+
+---
+
+## Notes for the executing agent
+
+- The migration test in Task 2 will run BEFORE the smoke tests in Task 5 are fixed. Expect some smoke tests to fail after Task 2 commits because they try to insert stickers without a `slug` field. Task 5 fixes them. Do not panic during the intermediate broken state — that's expected. Run the migration test in isolation if needed: `npm test -- --test-name-pattern='add_sticker_slug migration'`.
+
+- The Remix 3 controller pattern: every handler returns a `Response` explicitly. `notFound()` is a helper defined locally in some controllers (look for it). If it's not in scope at a particular site, use `new Response('Not Found', { status: 404 })`.
+
+- The repository convention for migrations is **SQL only** (`up.sql`/`down.sql` files in a timestamped directory). Do not use the `createMigration` TS API mentioned in some Remix docs — it is not wired into our `scripts/migrate.ts`.
+
+- `routes.sticker.href({ slug })` and `routes.editSticker.index.href({ slug })` are the typed builders. Always use them rather than constructing URL strings by hand. The typechecker will catch missing or wrong-named params.
+
+- If `npm test` hangs or warns about open handles, check whether a test forgot to call `env.cleanup()` in a `finally` block. Every test in this codebase uses `try { ... } finally { env.cleanup() }`.
+
+- The `gh pr create` command in Task 8 may fail if the user has a different default remote or branch protection. If it does, fall back to printing the suggested PR title and body and ask the user to create the PR manually.

--- a/docs/superpowers/specs/2026-06-03-sticker-slugs-design.md
+++ b/docs/superpowers/specs/2026-06-03-sticker-slugs-design.md
@@ -1,0 +1,258 @@
+# Sticker Slugs Design
+
+**Status:** Approved, ready for implementation plan
+**Date:** 2026-06-03
+
+## Goal
+
+Replace UUIDs in public-facing sticker URLs with human-readable slugs. Same
+treatment will apply to surfaces when that feature lands.
+
+Today: `/sticker/5a2077e8-ef49-446b-aa27-dca99e15a9b4`
+After:  `/sticker/dino-sticker-k3p9aq`
+
+## Scope
+
+### In scope
+
+- `/sticker/:id` → `/sticker/:slug` (public show page)
+- `/sticker/:id/edit` → `/sticker/:slug/edit` (edit form GET + POST)
+- Schema migration: add `slug` column to `stickers`
+- Backfill slugs for existing stickers
+- UUID-shaped `:slug` values 301-redirect to the slug URL (preserves any
+  existing shared links)
+
+### Out of scope
+
+- JSON API (`/api/stickers/:id` stays UUID — APIs prefer stable opaque IDs)
+- All form action / POST targets, which are never shared as links:
+  - `/profile/:username/remove-sticker/:stickerId`
+  - `/admin/stickers/:id/delete`, `/admin/users/:id/delete`
+  - `/account/tokens/:id/revoke`
+  - `/invitations/:id/destroy`
+- Invitations (`/invitation/:id`) — security-sensitive, UUID's unguessability
+  is a feature, not a bug
+- Slug regeneration on rename — the slug is frozen at sticker creation. If
+  the name changes, the URL keeps the old slug. Matches our existing stance
+  on usernames (also mutable, also not redirected).
+- Sticker surfaces — separate feature; this design just establishes the
+  pattern they'll reuse
+
+## Slug Format
+
+`<slug-part>-<suffix>`, where:
+
+- **slug-part:** lowercase, ASCII alphanumeric and hyphens only, derived
+  from the sticker name. Multiple non-alphanumeric chars collapse to a
+  single hyphen; leading/trailing hyphens trimmed. Hard-capped at 40
+  chars (trim, then re-trim any trailing hyphen left by the cut).
+- **suffix:** 6 lowercase alphanumeric chars (`a-z0-9`), generated randomly
+  at create time. ~31 bits of entropy, ~2B values — far more than this
+  invite-only site will ever need. No collision-retry logic; we'll let
+  SQLite's UNIQUE constraint surface the (vanishingly rare) collision and
+  let the request fail. If it ever happens in practice, we revisit.
+
+### Examples
+
+| Name | Slug |
+| --- | --- |
+| `Dino Sticker` | `dino-sticker-k3p9aq` |
+| `coffee & code` | `coffee-code-x7m2zp` |
+| `🦖` | `k3p9aq` (suffix only, slug-part empty) |
+| `   ` | `k3p9aq` (suffix only) |
+| `A` × 200 | `<40 a's>-k3p9aq` (slug-part hard-capped at 40 chars) |
+
+### Edge cases
+
+- **Empty slug-part:** if slugifying the name yields an empty string (emoji
+  names, whitespace-only names), the URL is just the suffix:
+  `/sticker/k3p9aq`. Acceptable degradation.
+- **Slugs that look like UUIDs:** essentially impossible — UUIDs contain
+  hyphens at fixed positions and a fixed length (36 chars). Our slugs end
+  in `-` + 6 chars and start with name-derived text. The UUID detector
+  used for the redirect path is the standard UUID regex, which won't false-
+  positive on our slugs.
+
+## Schema Change
+
+Our migration system is pure SQL (`migrations/<ts>_<slug>/{up,down}.sql`,
+loaded by `remix/data-table/migrations/node`). No JS hook mid-migration.
+This rules out generating name-derived slugs for existing stickers from
+inside the migration. We accept that pre-migration stickers get
+**suffix-only slugs** (e.g. `/sticker/a3f9b1`) and only new stickers get
+the prettier `<name>-<suffix>` form. The number of pre-migration
+stickers is tiny (handful in dev, small in prod), so this is fine.
+
+**Migration up:** `<ts>_add_sticker_slug/up.sql`
+
+```sql
+ALTER TABLE stickers ADD COLUMN slug TEXT NOT NULL DEFAULT '';
+UPDATE stickers SET slug = lower(hex(randomblob(3))) WHERE slug = '';
+CREATE UNIQUE INDEX stickers_slug_unique ON stickers(slug);
+```
+
+`hex(randomblob(3))` yields 6 lowercase-hex chars (`0-9a-f`), which is a
+subset of our `0-9a-z` runtime alphabet — backfilled slugs look the
+same shape as freshly-generated ones, so lookup code doesn't need to
+special-case them.
+
+**Migration down:** `<ts>_add_sticker_slug/down.sql`
+
+```sql
+DROP INDEX stickers_slug_unique;
+ALTER TABLE stickers DROP COLUMN slug;
+```
+
+(SQLite 3.35+ supports `DROP COLUMN`.)
+
+All three `up.sql` steps run in the migration runner's transaction.
+Partial failure rolls the whole thing back.
+
+The TypeScript schema in `app/data/schema.ts` gets:
+
+```ts
+export const stickers = table({
+  name: 'stickers',
+  columns: {
+    id: c.text().primaryKey(),
+    name: c.text().notNull(),
+    slug: c.text().notNull().unique(),  // new
+    image_url: c.text().notNull(),
+    owner_id: c.text(),
+    created_at: c.integer().notNull(),
+    updated_at: c.integer().notNull(),
+  },
+})
+```
+
+## Code Changes
+
+### New module: `app/data/slug.ts`
+
+Two exports:
+
+```ts
+// "Dino Sticker" -> "dino-sticker"
+// "🦖" -> ""
+// trims to 40 chars max
+export function slugifyName(name: string): string
+
+// "Dino Sticker" -> "dino-sticker-k3p9aq"
+// "" -> "k3p9aq"
+export function generateStickerSlug(name: string): string
+```
+
+`generateStickerSlug` calls `slugifyName`, generates 6 random `a-z0-9`
+chars via `node:crypto`, and joins with a hyphen (or returns just the
+suffix if the slug-part is empty).
+
+No external dependency for the suffix — `crypto.randomBytes` + a small
+alphabet-encoder is enough. The existing codebase already uses
+`node:crypto` for tokens.
+
+### Route contract: `app/routes.ts`
+
+```ts
+sticker: '/sticker/:slug',
+editSticker: form('/sticker/:slug/edit'),
+```
+
+Param name changes from `id` to `slug`. Every `routes.sticker.href({ id })`
+call site updates to `routes.sticker.href({ slug })`. Without the rename
+the typechecker would silently accept stale call sites; with it, every
+call site fails until updated.
+
+### Controller updates
+
+Look up by slug instead of id. Add UUID-detection redirect at the top of
+each show/edit handler:
+
+```ts
+const param = context.params.slug
+if (UUID_REGEX.test(param)) {
+  const sticker = await db.findOne(stickers, { where: { id: param } })
+  if (!sticker) return notFound(...)
+  return redirect(routes.sticker.href({ slug: sticker.slug }), 301)
+}
+const sticker = await db.findOne(stickers, { where: { slug: param } })
+```
+
+Call sites to update (already inventoried, ~7 sites):
+- `app/actions/controller.tsx` sticker show
+- `app/actions/edit-sticker/controller.tsx` (GET + POST)
+- `app/actions/upload-sticker/controller.tsx` (post-create redirect)
+- `app/ui/sticker-card.tsx`
+- `app/actions/admin/admin-stickers-page.tsx`
+- `app/actions/sticker-page.tsx` (OG canonical URL)
+- `app/actions/edit-sticker-page.tsx` (cancel link)
+
+### Sticker creation
+
+`upload-sticker/controller.tsx` calls `generateStickerSlug(name)` and
+inserts both `id` (UUID, unchanged) and `slug`. Post-create redirect uses
+the new slug.
+
+### Sticker rename
+
+`edit-sticker/controller.tsx` does NOT recompute the slug. Frozen-at-
+create, as discussed.
+
+### Tests
+
+Update `test/smoke.test.ts`:
+- The two existing references to `routes.sticker.href({ id: stickerId })`
+  switch to `{ slug: stickerSlug }`. The test will need to read the slug
+  off the created sticker (either from the redirect's `Location` header
+  or from a DB query in the test helper).
+- Add a new test: GET `/sticker/<uuid>` 301-redirects to `/sticker/<slug>`
+  for an existing sticker.
+- Add a new test: GET `/sticker/<uuid>` returns 404 for a non-existent
+  UUID (regression — current behaviour).
+
+### Documentation
+
+Roadmap entry under "Recently shipped" once landed. Brief mention.
+
+## Migration & Rollout
+
+1. Land the migration + backfill in a single PR. Existing dev DBs need
+   `npm run migrate` to pick up the new column.
+2. Prod gets the new column auto-applied on container boot via the
+   existing migration-on-boot setup.
+3. UUID-redirect path means any links shared before today keep working
+   indefinitely. We can keep the redirect path forever — it's ~6 lines.
+
+## Risks
+
+- **`remix/data-table` `.unique()` on a new column:** confirm whether
+  `.unique()` is honoured by the migration generator or only by the
+  query builder. If only the latter, we need the raw `CREATE UNIQUE
+  INDEX` in the migration SQL too (it's already there in this design).
+- **`form()` route param rename:** Remix 3's `form()` macro accepts both
+  GET and POST. POST requests to `/sticker/<uuid>/edit` won't hit the
+  redirect path (we only redirect on GET). If someone bookmarks the
+  edit page by UUID and submits, the POST will 404. Mitigation: the
+  redirect handler runs on GET only; users land on the new URL before
+  they submit, so the form's POST always targets the slug URL. Worst
+  case: a stale bookmark to the edit page 404s on submit, which the
+  user can recover from by re-navigating. Acceptable.
+- **Migration backfill atomicity:** addressed by putting the
+  `ALTER TABLE`, the backfill `UPDATE`, and the `CREATE UNIQUE INDEX`
+  all in the same migration file. The migration runner runs each file
+  in a transaction; if anything fails the whole migration rolls back.
+- **`hex(randomblob(3))` collision for backfilled rows:** 16M values
+  for ~dozens of pre-existing stickers means collision probability is
+  negligible. If it happens, the unique index creation fails, the
+  migration rolls back, and we re-run (different random output).
+
+## Verification
+
+After implementation:
+
+- `npm test` — all 36 existing tests pass, plus the 2 new ones
+- `npm run typecheck` — clean
+- Manual browser check:
+  - Upload a new sticker, verify the URL is `/sticker/<name>-<6chars>`
+  - Visit the old UUID URL of an existing sticker, verify the 301
+  - Rename a sticker, verify the URL stays the same (frozen slug)
+  - Upload a sticker named `🦖`, verify URL is just the suffix

--- a/docs/superpowers/specs/2026-06-03-sticker-slugs-design.md
+++ b/docs/superpowers/specs/2026-06-03-sticker-slugs-design.md
@@ -76,25 +76,51 @@ After:  `/sticker/dino-sticker-k3p9aq`
 ## Schema Change
 
 Our migration system is pure SQL (`migrations/<ts>_<slug>/{up,down}.sql`,
-loaded by `remix/data-table/migrations/node`). No JS hook mid-migration.
-This rules out generating name-derived slugs for existing stickers from
-inside the migration. We accept that pre-migration stickers get
-**suffix-only slugs** (e.g. `/sticker/a3f9b1`) and only new stickers get
-the prettier `<name>-<suffix>` form. The number of pre-migration
-stickers is tiny (handful in dev, small in prod), so this is fine.
+loaded by `remix/data-table/migrations/node`). One migration file does the
+whole job: add the column, backfill name-derived slugs for existing rows,
+add the unique index.
+
+The backfill SQL is the "good enough" version: it lowercases, replaces
+common word separators with hyphens, trims edge hyphens, and appends a
+random 6-char hex suffix. It does NOT try to perfectly mirror the
+runtime `slugifyName` (which strips all non-alphanumerics and caps at 40
+chars). For typical names like "Dino Sticker" the backfill produces the
+same result as the runtime function. For weird names ("🦖 fire 🦖") it
+produces `🦖-fire-🦖-a3f9b1` — URL-encoded but functional, and unique
+thanks to the suffix. We accept this asymmetry because:
+
+- The backfill runs once, against a handful of existing stickers.
+- All future stickers go through the polished runtime function.
+- Lookup is by exact-match on the slug column, so the shape doesn't
+  matter — it just needs to be unique and stable.
 
 **Migration up:** `<ts>_add_sticker_slug/up.sql`
 
 ```sql
 ALTER TABLE stickers ADD COLUMN slug TEXT NOT NULL DEFAULT '';
-UPDATE stickers SET slug = lower(hex(randomblob(3))) WHERE slug = '';
+
+-- Backfill: replace common separators with hyphens, lowercase, trim
+-- edge hyphens, append a random 6-char hex suffix.
+UPDATE stickers
+SET slug = trim(
+  replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(
+    lower(name),
+    ' ', '-'), '_', '-'), '.', '-'), ',', '-'), '!', '-'),
+    '?', '-'), ':', '-'), ';', '-'), '/', '-'), '\', '-'),
+  '-'
+) || '-' || lower(hex(randomblob(3)))
+WHERE slug = '';
+
+-- Strip any rows that ended up with a leading '-' (name was all
+-- separators). The suffix still keeps them unique.
+UPDATE stickers SET slug = substr(slug, 2) WHERE slug LIKE '-%';
+
 CREATE UNIQUE INDEX stickers_slug_unique ON stickers(slug);
 ```
 
-`hex(randomblob(3))` yields 6 lowercase-hex chars (`0-9a-f`), which is a
-subset of our `0-9a-z` runtime alphabet — backfilled slugs look the
-same shape as freshly-generated ones, so lookup code doesn't need to
-special-case them.
+`hex(randomblob(3))` yields 6 lowercase-hex chars (`0-9a-f`), a subset of
+the runtime `0-9a-z` alphabet — backfilled slugs look like
+freshly-generated ones, so lookup code doesn't special-case them.
 
 **Migration down:** `<ts>_add_sticker_slug/down.sql`
 
@@ -105,8 +131,34 @@ ALTER TABLE stickers DROP COLUMN slug;
 
 (SQLite 3.35+ supports `DROP COLUMN`.)
 
-All three `up.sql` steps run in the migration runner's transaction.
-Partial failure rolls the whole thing back.
+All `up.sql` steps run in the migration runner's transaction. Partial
+failure rolls the whole thing back.
+
+### Migration test
+
+Add `test/migrations.test.ts`. Flow:
+
+1. Build a fresh in-memory SQLite via the existing test harness.
+2. Apply all migrations *up to but not including* the sticker-slug one.
+3. Insert several stickers with known names (`"Dino Sticker"`,
+   `"hello"`, `"!!!"`, `"🦖"`) — no slug column yet.
+4. Apply the sticker-slug migration. The backfill UPDATE runs as part
+   of that migration.
+5. Read each sticker back and assert the slug matches the expected
+   regex.
+
+Assertions:
+
+- `"Dino Sticker"` → matches `^dino-sticker-[0-9a-f]{6}$`
+- `"hello"` → matches `^hello-[0-9a-f]{6}$`
+- `"!!!"` → matches `^[0-9a-f]{6}$` (all-separator name → suffix only)
+- `"🦖"` → matches `^🦖-[0-9a-f]{6}$` (emoji preserved, suffix appended)
+- All slugs are unique
+- The unique index is present: a subsequent `INSERT` with a duplicate
+  slug fails
+
+This covers the SQL backfill end-to-end. The runtime `slugifyName` and
+`generateStickerSlug` get their own pure-function unit tests.
 
 The TypeScript schema in `app/data/schema.ts` gets:
 
@@ -215,19 +267,16 @@ Roadmap entry under "Recently shipped" once landed. Brief mention.
 
 ## Migration & Rollout
 
-1. Land the migration + backfill in a single PR. Existing dev DBs need
-   `npm run migrate` to pick up the new column.
-2. Prod gets the new column auto-applied on container boot via the
-   existing migration-on-boot setup.
+1. Land the migration + backfill SQL in a single PR. Existing dev DBs
+   pick up the change via `npm run migrate`.
+2. Prod gets the new column + backfill auto-applied on container boot
+   via the existing migration-on-boot setup. Single deploy, no operator
+   step.
 3. UUID-redirect path means any links shared before today keep working
    indefinitely. We can keep the redirect path forever — it's ~6 lines.
 
 ## Risks
 
-- **`remix/data-table` `.unique()` on a new column:** confirm whether
-  `.unique()` is honoured by the migration generator or only by the
-  query builder. If only the latter, we need the raw `CREATE UNIQUE
-  INDEX` in the migration SQL too (it's already there in this design).
 - **`form()` route param rename:** Remix 3's `form()` macro accepts both
   GET and POST. POST requests to `/sticker/<uuid>/edit` won't hit the
   redirect path (we only redirect on GET). If someone bookmarks the
@@ -236,20 +285,23 @@ Roadmap entry under "Recently shipped" once landed. Brief mention.
   they submit, so the form's POST always targets the slug URL. Worst
   case: a stale bookmark to the edit page 404s on submit, which the
   user can recover from by re-navigating. Acceptable.
-- **Migration backfill atomicity:** addressed by putting the
-  `ALTER TABLE`, the backfill `UPDATE`, and the `CREATE UNIQUE INDEX`
-  all in the same migration file. The migration runner runs each file
-  in a transaction; if anything fails the whole migration rolls back.
 - **`hex(randomblob(3))` collision for backfilled rows:** 16M values
   for ~dozens of pre-existing stickers means collision probability is
   negligible. If it happens, the unique index creation fails, the
   migration rolls back, and we re-run (different random output).
+- **Backfill SQL diverges from runtime slugify:** intentional and
+  documented above. The migration test pins the exact SQL behavior so
+  any future change is explicit.
 
 ## Verification
 
 After implementation:
 
-- `npm test` — all 36 existing tests pass, plus the 2 new ones
+- `npm test` — all 36 existing tests pass, plus new ones:
+  - `test/migrations.test.ts` (backfill SQL produces expected slugs)
+  - Pure-function unit tests for `slugifyName` and `generateStickerSlug`
+  - Smoke test: GET `/sticker/<uuid>` 301-redirects to slug URL
+  - Smoke test: GET `/sticker/<uuid>` returns 404 for nonexistent UUID
 - `npm run typecheck` — clean
 - Manual browser check:
   - Upload a new sticker, verify the URL is `/sticker/<name>-<6chars>`

--- a/migrations/20260603000000_add_sticker_slug/down.sql
+++ b/migrations/20260603000000_add_sticker_slug/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX stickers_slug_unique;
+ALTER TABLE stickers DROP COLUMN slug;

--- a/migrations/20260603000000_add_sticker_slug/up.sql
+++ b/migrations/20260603000000_add_sticker_slug/up.sql
@@ -1,0 +1,23 @@
+ALTER TABLE stickers ADD COLUMN slug TEXT NOT NULL DEFAULT '';
+
+-- Backfill: lowercase the name, replace common separators with hyphens,
+-- trim edge hyphens, append a random 6-char hex suffix.
+-- This is the "good enough" SQL version of slugifyName -- it handles
+-- common cases (spaces, basic punctuation) but does not strip every
+-- non-alphanumeric the way the TS function does. Acceptable: this only
+-- runs once against existing rows; new stickers go through the TS helper.
+UPDATE stickers
+SET slug = trim(
+  replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(
+    lower(name),
+    ' ', '-'), '_', '-'), '.', '-'), ',', '-'), '!', '-'),
+    '?', '-'), ':', '-'), ';', '-'), '/', '-'), '\', '-'),
+  '-'
+) || '-' || lower(hex(randomblob(3)))
+WHERE slug = '';
+
+-- Strip rows that ended up with a leading '-' (name was all separators
+-- on the left). The suffix still keeps them unique.
+UPDATE stickers SET slug = substr(slug, 2) WHERE slug LIKE '-%';
+
+CREATE UNIQUE INDEX stickers_slug_unique ON stickers(slug);

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs'
 
 import { db } from '../app/data/db.ts'
 import { config, invitations, stickers, users, UserRoles } from '../app/data/schema.ts'
+import { generateStickerSlug } from '../app/data/slug.ts'
 
 async function upsertConfig() {
   const existing = await db.findOne(config, { where: { id: 1 } })
@@ -55,6 +56,7 @@ async function maybeSeedSample(adminId: string) {
   await db.create(stickers, {
     id: randomUUID(),
     name: 'sample sticker',
+    slug: generateStickerSlug('sample sticker'),
     image_url: '/images/banner.png',
     owner_id: aliceId,
     created_at: now,

--- a/test/migrations.test.ts
+++ b/test/migrations.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { DatabaseSync } from 'node:sqlite'
+import { createDatabase } from 'remix/data-table'
+import { createSqliteDatabaseAdapter } from 'remix/data-table/sqlite'
+import { createMigrationRunner } from 'remix/data-table/migrations'
+import { loadMigrations } from 'remix/data-table/migrations/node'
+
+import { stickers } from '../app/data/schema.ts'
+
+const SLUG_MIGRATION_ID = '20260603000000'
+
+describe('add_sticker_slug migration', () => {
+  it('backfills name-derived slugs and enforces uniqueness', async () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'stickertrade-mig-test-'))
+    const dbPath = path.join(tmpDir, 'mig.sqlite')
+    const sqlite = new DatabaseSync(dbPath)
+    sqlite.exec('PRAGMA foreign_keys = ON')
+
+    try {
+      const adapter = createSqliteDatabaseAdapter(sqlite)
+      const db = createDatabase(adapter)
+      const allMigrations = await loadMigrations('./migrations')
+
+      // Find the migration immediately before the slug one and run up to it.
+      const slugIdx = allMigrations.findIndex((m) => m.id === SLUG_MIGRATION_ID)
+      assert.ok(slugIdx > 0, 'slug migration must exist with previous migrations applied')
+      const previousId = allMigrations[slugIdx - 1]!.id
+
+      const runner = createMigrationRunner(adapter, allMigrations)
+      await runner.up({ to: previousId })
+
+      // Insert stickers using raw SQL because the schema in code already
+      // has the slug column, but at this point in time the DB does not.
+      const now = Date.now()
+      const insert = sqlite.prepare(
+        'INSERT INTO stickers (id, name, image_url, owner_id, created_at, updated_at) VALUES (?, ?, ?, NULL, ?, ?)',
+      )
+      const fixtures = [
+        { id: randomUUID(), name: 'Dino Sticker', expect: /^dino-sticker-[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: 'hello', expect: /^hello-[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: '!!!', expect: /^[0-9a-f]{6}$/ },
+        { id: randomUUID(), name: '🦖', expect: /^🦖-[0-9a-f]{6}$/ },
+      ]
+      for (const f of fixtures) {
+        insert.run(f.id, f.name, '/uploads/test.png', now, now)
+      }
+
+      // Now apply the slug migration. The backfill UPDATE runs inside it.
+      await runner.up({ to: SLUG_MIGRATION_ID })
+
+      // Each sticker should now have a slug matching its expected pattern.
+      const slugs: string[] = []
+      for (const f of fixtures) {
+        const row = await db.findOne(stickers, { where: { id: f.id } })
+        assert.ok(row, `sticker ${f.name} not found`)
+        assert.match(row.slug, f.expect, `slug for ${JSON.stringify(f.name)} = ${JSON.stringify(row.slug)}`)
+        slugs.push(row.slug)
+      }
+
+      // All slugs unique.
+      assert.equal(new Set(slugs).size, slugs.length, 'slugs should be unique')
+
+      // The unique index rejects duplicates.
+      const dupId = randomUUID()
+      assert.throws(
+        () => {
+          sqlite
+            .prepare(
+              'INSERT INTO stickers (id, name, slug, image_url, owner_id, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?)',
+            )
+            .run(dupId, 'dup', slugs[0]!, '/uploads/x.png', now, now)
+        },
+        /UNIQUE/,
+      )
+    } finally {
+      sqlite.close()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/slug.test.ts
+++ b/test/slug.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { generateStickerSlug, slugifyName } from '../app/data/slug.ts'
+import { generateStickerSlug, looksLikeUuid, slugifyName } from '../app/data/slug.ts'
 
 describe('slugifyName', () => {
   it('lowercases and hyphenates spaces', () => {
@@ -47,5 +47,25 @@ describe('generateStickerSlug', () => {
     const a = generateStickerSlug('test')
     const b = generateStickerSlug('test')
     assert.notEqual(a, b)
+  })
+})
+
+describe('looksLikeUuid', () => {
+  it('returns true for canonical lowercase UUIDs', () => {
+    assert.equal(looksLikeUuid('5a2077e8-ef49-446b-aa27-dca99e15a9b4'), true)
+  })
+
+  it('returns true for uppercase UUIDs', () => {
+    assert.equal(looksLikeUuid('5A2077E8-EF49-446B-AA27-DCA99E15A9B4'), true)
+  })
+
+  it('returns false for sticker slugs', () => {
+    assert.equal(looksLikeUuid('dino-sticker-k3p9aq'), false)
+    assert.equal(looksLikeUuid('a3f9b1'), false)
+  })
+
+  it('returns false for empty / partial strings', () => {
+    assert.equal(looksLikeUuid(''), false)
+    assert.equal(looksLikeUuid('5a2077e8-ef49-446b-aa27'), false)
   })
 })

--- a/test/slug.test.ts
+++ b/test/slug.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { generateStickerSlug, slugifyName } from '../app/data/slug.ts'
+
+describe('slugifyName', () => {
+  it('lowercases and hyphenates spaces', () => {
+    assert.equal(slugifyName('Dino Sticker'), 'dino-sticker')
+  })
+
+  it('strips non-alphanumeric chars and collapses runs of hyphens', () => {
+    assert.equal(slugifyName('coffee & code'), 'coffee-code')
+    assert.equal(slugifyName('foo!!!bar???baz'), 'foo-bar-baz')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    assert.equal(slugifyName('---hello---'), 'hello')
+    assert.equal(slugifyName('   spaced   '), 'spaced')
+  })
+
+  it('returns an empty string for all-non-ASCII names', () => {
+    assert.equal(slugifyName('🦖'), '')
+    assert.equal(slugifyName('🦖 🔥 🦖'), '')
+  })
+
+  it('caps at 40 chars and re-trims trailing hyphen left by the cut', () => {
+    const longName = 'a'.repeat(200)
+    assert.equal(slugifyName(longName), 'a'.repeat(40))
+    const oddCut = 'a'.repeat(39) + ' ' + 'b'.repeat(50)
+    // 'aaaa...aaa-bbbb...' — first 40 chars is 39 a's + '-' which trims to 39 a's
+    assert.equal(slugifyName(oddCut), 'a'.repeat(39))
+  })
+})
+
+describe('generateStickerSlug', () => {
+  it('produces <slug-part>-<6 lowercase alphanumerics>', () => {
+    const slug = generateStickerSlug('Dino Sticker')
+    assert.match(slug, /^dino-sticker-[a-z0-9]{6}$/)
+  })
+
+  it('produces just the suffix when the name slugifies to empty', () => {
+    const slug = generateStickerSlug('🦖')
+    assert.match(slug, /^[a-z0-9]{6}$/)
+  })
+
+  it('produces different suffixes across calls', () => {
+    const a = generateStickerSlug('test')
+    const b = generateStickerSlug('test')
+    assert.notEqual(a, b)
+  })
+})

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -434,6 +434,7 @@ describe('edit sticker', () => {
       const updated = await env.db.findOne(stickers, { where: { id: stickerId } })
       assert.ok(updated)
       assert.equal(updated.name, 'new shiny name')
+      assert.equal(updated.slug, stickerSlug, 'slug should be frozen on rename')
     } finally {
       env.cleanup()
     }
@@ -489,9 +490,7 @@ describe('sticker URL backwards compatibility', () => {
         updated_at: Date.now(),
       })
 
-      const res = await env.fetch(
-        new Request(buildUrl(`/sticker/${stickerId}`), { redirect: 'manual' }),
-      )
+      const res = await env.fetch(new Request(buildUrl(`/sticker/${stickerId}`)))
       assert.equal(res.status, 301)
       assert.equal(res.headers.get('location'), `/sticker/${stickerSlug}`)
     } finally {

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test'
 import bcrypt from 'bcryptjs'
 
 import { invitations, stickers, users, UserRoles } from '../app/data/schema.ts'
+import { generateStickerSlug } from '../app/data/slug.ts'
 import { routes } from '../app/routes.ts'
 import {
   buildUrl,
@@ -259,6 +260,7 @@ describe('admin', () => {
       await env.db.create(stickers, {
         id: stickerId,
         name: 'soon-gone',
+        slug: generateStickerSlug('soon-gone'),
         image_url: '/images/banner.png',
         owner_id: aliceId,
         created_at: Date.now(),
@@ -401,9 +403,12 @@ describe('edit sticker', () => {
     try {
       const ownerId = await seedUser(env, 'grace', 'gracepass')
       const stickerId = randomUUID()
+      const stickerName = 'old name'
+      const stickerSlug = generateStickerSlug(stickerName)
       await env.db.create(stickers, {
         id: stickerId,
-        name: 'old name',
+        name: stickerName,
+        slug: stickerSlug,
         image_url: '/images/banner.png',
         owner_id: ownerId,
         created_at: Date.now(),
@@ -413,18 +418,18 @@ describe('edit sticker', () => {
       const sessionCookie = await loginAs(env, 'grace', 'gracepass')
       const { token, cookie } = await fetchCsrf(
         env,
-        routes.editSticker.index.href({ id: stickerId }),
+        routes.editSticker.index.href({ slug: stickerSlug }),
         sessionCookie,
       )
       const body = new FormData()
       body.set('_csrf', token)
       body.set('name', 'new shiny name')
-      const res = await postForm(env, routes.editSticker.action.href({ id: stickerId }), {
+      const res = await postForm(env, routes.editSticker.action.href({ slug: stickerSlug }), {
         cookie,
         body,
       })
       assert.equal(res.status, 303)
-      assert.equal(res.headers.get('location'), routes.sticker.href({ id: stickerId }))
+      assert.equal(res.headers.get('location'), routes.sticker.href({ slug: stickerSlug }))
 
       const updated = await env.db.findOne(stickers, { where: { id: stickerId } })
       assert.ok(updated)
@@ -440,9 +445,12 @@ describe('edit sticker', () => {
       const ownerId = await seedUser(env, 'henry', 'henrypass')
       await seedUser(env, 'intruder', 'intruderpass')
       const stickerId = randomUUID()
+      const stickerName = 'mine'
+      const stickerSlug = generateStickerSlug(stickerName)
       await env.db.create(stickers, {
         id: stickerId,
-        name: 'mine',
+        name: stickerName,
+        slug: stickerSlug,
         image_url: '/images/banner.png',
         owner_id: ownerId,
         created_at: Date.now(),
@@ -452,11 +460,51 @@ describe('edit sticker', () => {
       const sessionCookie = await loginAs(env, 'intruder', 'intruderpass')
       // Intruder can't reach the edit page either.
       const get = await env.fetch(
-        new Request(buildUrl(routes.editSticker.index.href({ id: stickerId })), {
+        new Request(buildUrl(routes.editSticker.index.href({ slug: stickerSlug })), {
           headers: { cookie: sessionCookie },
         }),
       )
       assert.equal(get.status, 403)
+    } finally {
+      env.cleanup()
+    }
+  })
+})
+
+describe('sticker URL backwards compatibility', () => {
+  it('301-redirects /sticker/<uuid> to the slug URL', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'redirector', 'redirectorpass')
+      const stickerId = randomUUID()
+      const stickerName = 'Vintage'
+      const stickerSlug = generateStickerSlug(stickerName)
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: stickerName,
+        slug: stickerSlug,
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const res = await env.fetch(
+        new Request(buildUrl(`/sticker/${stickerId}`), { redirect: 'manual' }),
+      )
+      assert.equal(res.status, 301)
+      assert.equal(res.headers.get('location'), `/sticker/${stickerSlug}`)
+    } finally {
+      env.cleanup()
+    }
+  })
+
+  it('returns 404 for a /sticker/<uuid> with no matching sticker', async () => {
+    const env = await createTestEnv()
+    try {
+      const phantomId = randomUUID()
+      const res = await env.fetch(new Request(buildUrl(`/sticker/${phantomId}`)))
+      assert.equal(res.status, 404)
     } finally {
       env.cleanup()
     }
@@ -562,6 +610,7 @@ describe('api: stickers', () => {
       await env.db.create(stickers, {
         id: stickerId,
         name: 'public sticker',
+        slug: generateStickerSlug('public sticker'),
         image_url: '/images/banner.png',
         owner_id: ownerId,
         created_at: Date.now(),
@@ -736,6 +785,7 @@ describe('api: stickers', () => {
       await env.db.create(stickers, {
         id: stickerId,
         name: 'old',
+        slug: generateStickerSlug('old'),
         image_url: '/images/banner.png',
         owner_id: userId,
         created_at: Date.now(),
@@ -771,6 +821,7 @@ describe('api: stickers', () => {
       await env.db.create(stickers, {
         id: stickerId,
         name: 'natefoo',
+        slug: generateStickerSlug('natefoo'),
         image_url: '/images/banner.png',
         owner_id: ownerId,
         created_at: Date.now(),
@@ -803,6 +854,7 @@ describe('api: stickers', () => {
       await env.db.create(stickers, {
         id: stickerId,
         name: 'going away',
+        slug: generateStickerSlug('going away'),
         image_url: '/images/banner.png',
         owner_id: userId,
         created_at: Date.now(),
@@ -830,6 +882,7 @@ describe('api: stickers', () => {
       await env.db.create(stickers, {
         id: randomUUID(),
         name: 'q1',
+        slug: generateStickerSlug('q1'),
         image_url: '/images/banner.png',
         owner_id: userId,
         created_at: Date.now(),
@@ -907,16 +960,19 @@ describe('og tags', () => {
     try {
       const ownerId = await seedUser(env, 'roxie', 'roxiepass')
       const stickerId = randomUUID()
+      const stickerName = 'cool og sticker'
+      const stickerSlug = generateStickerSlug(stickerName)
       await env.db.create(stickers, {
         id: stickerId,
-        name: 'cool og sticker',
+        name: stickerName,
+        slug: stickerSlug,
         image_url: '/uploads/stickers/cool.png',
         owner_id: ownerId,
         created_at: Date.now(),
         updated_at: Date.now(),
       })
 
-      const res = await env.fetch(new Request(buildUrl(routes.sticker.href({ id: stickerId }))))
+      const res = await env.fetch(new Request(buildUrl(routes.sticker.href({ slug: stickerSlug }))))
       const html = await res.text()
       assert.match(html, /<meta property="og:title" content="cool og sticker"/)
       assert.match(html, /<meta property="og:image" content="http:\/\/localhost(:\d+)?\/uploads\/stickers\/cool\.png"/)

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -508,6 +508,36 @@ describe('sticker URL backwards compatibility', () => {
       env.cleanup()
     }
   })
+
+  it('301-redirects /sticker/<uuid>/edit to the slug edit URL', async () => {
+    const env = await createTestEnv()
+    try {
+      const ownerId = await seedUser(env, 'edit-redirector', 'edit-redirectorpass')
+      const stickerId = randomUUID()
+      const stickerName = 'Antique'
+      const stickerSlug = generateStickerSlug(stickerName)
+      await env.db.create(stickers, {
+        id: stickerId,
+        name: stickerName,
+        slug: stickerSlug,
+        image_url: '/images/banner.png',
+        owner_id: ownerId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      })
+
+      const sessionCookie = await loginAs(env, 'edit-redirector', 'edit-redirectorpass')
+      const res = await env.fetch(
+        new Request(buildUrl(`/sticker/${stickerId}/edit`), {
+          headers: { cookie: sessionCookie },
+        }),
+      )
+      assert.equal(res.status, 301)
+      assert.equal(res.headers.get('location'), `/sticker/${stickerSlug}/edit`)
+    } finally {
+      env.cleanup()
+    }
+  })
 })
 
 describe('api tokens', () => {


### PR DESCRIPTION
Replace UUID-based sticker URLs with name-derived slugs.

`/sticker/5a2077e8-ef49-446b-aa27-dca99e15a9b4` → `/sticker/dino-sticker-k3p9aq`

## What changed

- New `slug` column on the `stickers` table, backfilled in a single SQL migration.
- `app/data/slug.ts` provides `slugifyName`, `generateStickerSlug`, and `looksLikeUuid`. Pure functions, fully unit-tested.
- Route contract: `/sticker/:id` → `/sticker/:slug`, same for the edit page.
- Old UUID URLs 301-redirect to the slug URL.
- Slug is frozen at sticker creation. Renaming does not regenerate.
- JSON API `JsonSticker` now exposes `slug` so machine consumers can build sticker URLs.

## What did NOT change

- JSON API `/api/stickers/:id` still uses UUID (the resource id is opaque on purpose).
- All form action / POST targets still use UUID (admin delete, remove-sticker, token revoke, invitations destroy).
- Invitations `/invitation/:id` keeps UUID (security-sensitive — unguessability is a feature).

## Verification

- 52 tests pass (was 36 on main): 12 slug unit tests (`slugifyName` / `generateStickerSlug` / `looksLikeUuid`), 1 migration test (inserts fixtures, runs migration, asserts backfilled slugs match regex + uniqueness), 3 smoke tests for UUID → slug redirects (show 301, edit 301, phantom-UUID 404), plus the frozen-slug rename assertion.
- Typecheck clean.
- Browser-verified end-to-end: UUID URL 301-redirects to slug URL (including non-ASCII slugs, which percent-encode in the Location header), phantom UUID 404s, slug URLs serve 200.

## Design + plan

- Spec: `docs/superpowers/specs/2026-06-03-sticker-slugs-design.md`
- Implementation plan: `docs/superpowers/plans/2026-06-03-sticker-slugs.md`

(Both committed for posterity. The plan is large — point reviewers at the spec for design intent and at the commits for the actual change.)