### PR TITLE
feat: persist surface of the day for proper cycling

### DIFF
--- a/app/data/surface-of-the-day.ts
+++ b/app/data/surface-of-the-day.ts
@@ -3,21 +3,34 @@ import type { Database } from 'remix/data-table'
 import { surfaces, surfaceFeatures, type Surface } from './schema.ts'
 
 /**
- * Lazy daily-pick algorithm. First request of the UTC day persists a
- * randomly chosen surface to `surface_features`; subsequent requests
- * read the cached row. If the cached pick has since been deleted, the
- * stale row is dropped and a fresh pick is rolled.
+ * Lazy daily-pick algorithm with full-rotation history. The first request of
+ * the UTC day persists a chosen surface to `surface_features`; subsequent
+ * requests reuse that cached row.
+ *
+ * Selection rules:
+ *   1. Surfaces that have never been featured are picked first (random
+ *      among them). This means newly uploaded surfaces always lead the
+ *      next pick.
+ *   2. Once every surface has been featured at least once, fall back to the
+ *      least-recently-featured surface, breaking ties at random. This keeps
+ *      the rotation cycling fairly even on small libraries.
  *
  * Race-safe: `featured_date` has a UNIQUE constraint, so concurrent
- * first-of-day requests can't write two rows — the loser catches the
- * error and re-reads.
+ * first-of-day requests can't write two rows — the loser catches the error
+ * and re-reads. If the cached pick has since been deleted (FK cascade
+ * usually handles this; the FK-bypass case is handled explicitly), the
+ * stale row is dropped and a fresh pick is rolled.
+ *
+ * `today` is exposed only so tests can simulate consecutive days without
+ * touching the system clock.
  */
-export async function getSurfaceOfTheDay(db: Database): Promise<Surface | null> {
-  const todayUtc = new Date().toISOString().slice(0, 10)
-
+export async function getSurfaceOfTheDay(
+  db: Database,
+  today: string = new Date().toISOString().slice(0, 10),
+): Promise<Surface | null> {
   // 1. Did we already pick today?
   const existing = await db.findOne(surfaceFeatures, {
-    where: { featured_date: todayUtc },
+    where: { featured_date: today },
   })
   if (existing) {
     const surface = await db.findOne(surfaces, { where: { id: existing.surface_id } })
@@ -27,20 +40,14 @@ export async function getSurfaceOfTheDay(db: Database): Promise<Surface | null> 
     await db.delete(surfaceFeatures, existing.id)
   }
 
-  // 2. Roll.
-  const total = await db.count(surfaces)
-  if (total === 0) return null
-
-  const offset = Math.floor(Math.random() * total)
-  const rolled = await db.query(surfaces).limit(1).offset(offset).all()
-  const chosen = rolled[0]
+  const chosen = await chooseSurface(db)
   if (!chosen) return null
 
-  // 3. Persist. UNIQUE on featured_date prevents concurrent double-writes.
+  // Persist. UNIQUE on featured_date prevents concurrent double-writes.
   try {
     await db.create(surfaceFeatures, {
       surface_id: chosen.id,
-      featured_date: todayUtc,
+      featured_date: today,
       created_at: Date.now(),
     })
     return chosen
@@ -48,9 +55,55 @@ export async function getSurfaceOfTheDay(db: Database): Promise<Surface | null> 
     // Lost the race? Re-read whatever the winning request wrote. If
     // there's no winner row, the original error wasn't a race — re-throw.
     const winner = await db.findOne(surfaceFeatures, {
-      where: { featured_date: todayUtc },
+      where: { featured_date: today },
     })
     if (!winner) throw err
     return db.findOne(surfaces, { where: { id: winner.surface_id } })
   }
+}
+
+/**
+ * Picks the next surface to feature. Prefers never-featured surfaces; if
+ * every surface has been featured at least once, picks at random from the
+ * surfaces tied for the oldest most-recent feature date.
+ *
+ * Returns `null` only when there are no surfaces at all.
+ */
+async function chooseSurface(db: Database): Promise<Surface | null> {
+  const allSurfaces = await db.findMany(surfaces, {})
+  if (allSurfaces.length === 0) return null
+
+  const features = await db.findMany(surfaceFeatures, {})
+
+  // Build surface_id -> most-recent featured_date map. featured_date is an
+  // ISO YYYY-MM-DD string, so lexicographic comparison matches calendar order.
+  const lastFeaturedAt = new Map<string, string>()
+  for (const feature of features) {
+    const prev = lastFeaturedAt.get(feature.surface_id)
+    if (prev === undefined || feature.featured_date > prev) {
+      lastFeaturedAt.set(feature.surface_id, feature.featured_date)
+    }
+  }
+
+  // Prefer surfaces that have never been featured.
+  const neverFeatured = allSurfaces.filter((s) => !lastFeaturedAt.has(s.id))
+  if (neverFeatured.length > 0) {
+    return pickRandom(neverFeatured)
+  }
+
+  // Everyone's been featured. Pick from the surfaces tied for the oldest
+  // most-recent feature date.
+  let oldest: string | undefined
+  for (const s of allSurfaces) {
+    const last = lastFeaturedAt.get(s.id)!
+    if (oldest === undefined || last < oldest) oldest = last
+  }
+  const oldestTier = allSurfaces.filter((s) => lastFeaturedAt.get(s.id) === oldest)
+  return pickRandom(oldestTier)
+}
+
+function pickRandom<T>(items: readonly T[]): T {
+  const offset = Math.floor(Math.random() * items.length)
+  // items.length >= 1 by construction at every call site.
+  return items[offset]!
 }

--- a/test/surface-of-the-day.test.ts
+++ b/test/surface-of-the-day.test.ts
@@ -181,6 +181,89 @@ describe('getSurfaceOfTheDay', () => {
     }
   })
 
+  it('does not repeat a surface until every other surface has been featured', async () => {
+    const env = await makeEnv()
+    try {
+      const ownerId = await makeUser(env, 'rotator')
+      const ids = new Set<string>()
+      ids.add(await makeSurface(env, ownerId, 'A'))
+      ids.add(await makeSurface(env, ownerId, 'B'))
+      ids.add(await makeSurface(env, ownerId, 'C'))
+
+      // Simulate three consecutive days. Inject the date so we don't have to
+      // mock the clock.
+      const day1 = await getSurfaceOfTheDay(env.db, '2030-01-01')
+      const day2 = await getSurfaceOfTheDay(env.db, '2030-01-02')
+      const day3 = await getSurfaceOfTheDay(env.db, '2030-01-03')
+
+      assert.ok(day1 && day2 && day3)
+      const picked = new Set([day1.id, day2.id, day3.id])
+      assert.equal(picked.size, 3, 'each of three days should yield a distinct surface')
+      assert.deepEqual([...picked].sort(), [...ids].sort())
+    } finally {
+      cleanup(env)
+    }
+  })
+
+  it('falls back to the least-recently-featured surface after a full rotation', async () => {
+    const env = await makeEnv()
+    try {
+      const ownerId = await makeUser(env, 'wrapper')
+      const aId = await makeSurface(env, ownerId, 'A')
+      const bId = await makeSurface(env, ownerId, 'B')
+
+      // Seed history: A featured first, B featured most recently.
+      await env.db.create(surfaceFeatures, {
+        surface_id: aId,
+        featured_date: '2030-02-01',
+        created_at: Date.now() - 86_400_000,
+      })
+      await env.db.create(surfaceFeatures, {
+        surface_id: bId,
+        featured_date: '2030-02-02',
+        created_at: Date.now(),
+      })
+
+      // Every surface has been featured. The next pick should reuse the
+      // least-recently-featured surface, which is A.
+      const result = await getSurfaceOfTheDay(env.db, '2030-02-03')
+      assert.ok(result)
+      assert.equal(result.id, aId)
+    } finally {
+      cleanup(env)
+    }
+  })
+
+  it('prioritises an unfeatured surface added mid-cycle', async () => {
+    const env = await makeEnv()
+    try {
+      const ownerId = await makeUser(env, 'newcomer')
+      const aId = await makeSurface(env, ownerId, 'A')
+      const bId = await makeSurface(env, ownerId, 'B')
+
+      await env.db.create(surfaceFeatures, {
+        surface_id: aId,
+        featured_date: '2030-03-01',
+        created_at: Date.now() - 172_800_000,
+      })
+      await env.db.create(surfaceFeatures, {
+        surface_id: bId,
+        featured_date: '2030-03-02',
+        created_at: Date.now() - 86_400_000,
+      })
+
+      // C is added after A and B have both been featured. It should be the
+      // next pick despite "least-recently-featured" being A.
+      const cId = await makeSurface(env, ownerId, 'C')
+
+      const result = await getSurfaceOfTheDay(env.db, '2030-03-03')
+      assert.ok(result)
+      assert.equal(result.id, cId)
+    } finally {
+      cleanup(env)
+    }
+  })
+
   it('drops a stale feature row whose surface was deleted (FK-bypass case)', async () => {
     const env = await makeEnv()
     try {


### PR DESCRIPTION
surfaces as they stand are randomized, which when little exist, we run the risk
of showing the same thing every day.

this pr:

* introduces persistence for the surface which shows each day.
* uses the persisted values to influence the selection of the random surface
being chosen each day
