### PR TITLE
deps: bump remix beta.2 → beta.4, marked 14 → 18, @types/node patch

### DIFF
--- a/.agents/skills/remix/SKILL.md
+++ b/.agents/skills/remix/SKILL.md
@@ -5,16 +5,11 @@ description: Build and review Remix 3 applications using the `remix` npm package
 
 # Build a Remix App
 
-Use this skill for end-to-end Remix app work. This skill helps you choose the right layer
-first, reach for the right package, and avoid the most common Remix-specific mistakes.
+Use this skill for end-to-end Remix app work. This skill helps you choose the right layer first, reach for the right package, and avoid the most common Remix-specific mistakes.
 
 ## Full Package Documentation
 
-This skill is the quick guide. When you need fuller API documentation, examples, or package-specific
-details for a `remix/*` subpath, first look for a README next to the relevant generated source file
-in the published `remix` package:
-`node_modules/remix/src/<subpath>/README.md`. If that README does not exist, look for the nearest
-parent README because some subpaths share their parent package documentation.
+This skill is the quick guide. When you need fuller API documentation, examples, or package-specific details for a `remix/*` subpath, first look for a README next to the relevant generated source file in the published `remix` package: `node_modules/remix/src/<subpath>/README.md`. These published README files are generated mirrors; in the Remix source repository, the canonical README lives in the owning `packages/*` package and the `packages/remix/src/**/README.md` mirrors are intentionally ignored. If that README does not exist, look for the nearest parent README because some subpaths share their parent package documentation.
 
 Examples:
 
@@ -23,37 +18,29 @@ Examples:
 
 ## What Remix Is
 
-Remix 3 is a server-first web framework built on Web APIs such as `Request`, `Response`, `URL`,
-and `FormData`. All packages ship from a single npm package, `remix`, and are imported via
-subpath. There is no top-level `remix` import.
+Remix 3 is a server-first web framework built on Web APIs such as `Request`, `Response`, `URL`, and `FormData`. All packages ship from a single npm package, `remix`, and are imported via subpath. There is no top-level `remix` import.
 
 A Remix app has four main pieces:
 
 - **Routes** in `app/routes.ts` define the typed URL contract and power `href()` generation.
 - **Controllers** in `app/actions` implement that contract and return `Response` objects.
-- **Middleware** composes request lifecycle behavior and populates typed context via
-  `context.set(Key, value)`.
-- **Components** render UI with `remix/ui`. This is not React. A component receives a
-  `handle`, reads current props from `handle.props`, and returns a zero-argument render function.
+- **Middleware** composes request lifecycle behavior and populates typed context via `context.set(Key, value)`.
+- **Components** render UI with `remix/ui`. This is not React. A component receives a `handle`, reads current props from `handle.props`, and returns a zero-argument render function.
 
 ## When To Use This Skill
 
 Use this skill for:
 
-- new features or refactors that touch routing, controllers, middleware, data, auth, sessions, UI,
-  or tests
+- new features or refactors that touch routing, controllers, middleware, data, auth, sessions, UI, or tests
 - reviewing Remix app code for correctness, architecture, or framework usage
 - answering "how should this be structured in Remix?" questions
 - finding the right package, reference doc, or default pattern for a task
 
 ## Load Only The References You Need
 
-Classify the task first, then load the smallest useful reference set. Each reference file starts
-with a "What This Covers" section that lists the topics inside it — read that first to confirm
-the file is relevant before reading the rest.
+Classify the task first, then load the smallest useful reference set. Each reference file starts with a "What This Covers" section that lists the topics inside it — read that first to confirm the file is relevant before reading the rest.
 
-Use the table below to find candidates. Loading more than two or three files at once is usually a
-sign that the task hasn't been narrowed enough yet.
+Use the table below to find candidates. Loading more than two or three files at once is usually a sign that the task hasn't been narrowed enough yet.
 
 | Task involves...                                                              | Start with                                  |
 | ----------------------------------------------------------------------------- | ------------------------------------------- |
@@ -73,33 +60,22 @@ Common bundles:
 
 - **Form or CRUD feature** -> routing, data and validation, testing; add auth if user-specific
 - **Protected area** -> auth and sessions, routing, testing
-- **Interactive widget** -> component model, mixins and styling; add hydration only if it runs in
-  the browser
+- **Interactive widget** -> component model, mixins and styling; add hydration only if it runs in the browser
 - **Browser asset pipeline** -> assets and browser modules, hydration, middleware and server
 - **File upload** -> middleware and server, data and validation, testing
 - **Navigation or frames** -> hydration, frames, navigation
 
 ## Default Workflow
 
-1. **Classify the change.** Decide whether it changes the route contract, request lifecycle, data
-   model, auth or session behavior, or only UI.
+1. **Classify the change.** Decide whether it changes the route contract, request lifecycle, data model, auth or session behavior, or only UI.
 2. **Start from the server contract.** Add or update `app/routes.ts` before wiring handlers or UI.
-3. **Put code in the narrowest owner.** Favor route-local code first, then promote only when reuse
-   is real.
-4. **Make the server path correct before adding browser behavior.** A route should return the right
-   `Response` via `router.fetch(...)` before you add `clientEntry(...)`, animations, or DOM
-   effects.
-5. **Add middleware deliberately.** Keep fast-exit middleware early and request-enriching
-   middleware later. Export a typed `AppContext` from the root middleware stack and use it in
-   controllers.
-6. **Validate input at the boundary.** Parse and validate `Request`, `FormData`, params, cookies,
-   and external payloads before they reach rendering or persistence logic.
-7. **Hydrate only when necessary.** Prefer server-rendered UI. Use `clientEntry(...)` and `run(...)`
-   only for real browser interactivity or browser-only APIs.
-8. **Test the narrowest meaningful layer.** Prefer router tests for route behavior. Use component
-   tests when the behavior is truly interactive or DOM-specific.
-9. **Finish with verification.** Re-read the route flow, confirm auth and authorization boundaries,
-   and run the smallest relevant test and typecheck loop.
+3. **Put code in the narrowest owner.** Favor route-local code first, then promote only when reuse is real.
+4. **Make the server path correct before adding browser behavior.** A route should return the right `Response` via `router.fetch(...)` before you add `clientEntry(...)`, animations, or DOM effects.
+5. **Add middleware deliberately.** Keep fast-exit middleware early and request-enriching middleware later. Export a typed `AppContext` from the middleware stack and use it in controllers.
+6. **Validate input at the boundary.** Parse and validate `Request`, `FormData`, params, cookies, and external payloads before they reach rendering or persistence logic.
+7. **Hydrate only when necessary.** Prefer server-rendered UI. Use `clientEntry(...)` and `run(...)` only for real browser interactivity or browser-only APIs.
+8. **Test the narrowest meaningful layer.** Prefer router tests for route behavior. Use component tests when the behavior is truly interactive or DOM-specific.
+9. **Finish with verification.** Re-read the route flow, confirm auth and authorization boundaries, and run the smallest relevant test and typecheck loop.
 
 ## Project Layout
 
@@ -114,11 +90,9 @@ Use these root directories consistently:
 Inside `app/`, organize by responsibility:
 
 - `assets/` for client entrypoints and client-owned browser behavior
-- `actions/` for controller-owned route handlers, route-local response rendering, and route-local
-  UI/helpers that are not shared across route areas
+- `actions/` for controller-owned route handlers, route-local response rendering, and route-local UI/helpers that are not shared across route areas
 - `data/` for schema, queries, persistence setup, migrations, and runtime data initialization
-- `middleware/` for request lifecycle concerns such as auth, sessions, uploads, and database
-  injection
+- `middleware/` for request lifecycle concerns such as auth, sessions, uploads, and database injection
 - `ui/` for shared cross-route UI primitives
 - `utils/` only for genuinely cross-layer helpers that do not clearly belong elsewhere
 - `routes.ts` for the route contract
@@ -138,83 +112,53 @@ When code could live in multiple places:
 ### Route Ownership
 
 - Put top-level leaf actions in `app/actions/controller.tsx`
-- A controller's `actions` object contains only direct leaf route keys from the route map passed to
-  `router.map(...)`
-- Add `app/actions/<route-key>/controller.tsx` for each nested route map that needs actions or
-  middleware, and map it explicitly with `router.map(routes.<routeKey>, controller)`
+- A controller's `actions` object contains only direct leaf route keys from the route map passed to `router.map(...)`
+- Add `app/actions/<route-key>/controller.tsx` for each nested route map that needs actions or controller middleware, and map it explicitly with `router.map(routes.<routeKey>, controller)`
 - Name directories under `app/actions/` after route-map keys, not URL path segments
 - Keep route-local UI and helpers next to the controller that owns them
 - Move shared cross-route UI to `app/ui/`
-- If a top-level leaf grows into a route map, move its handler into the nested route-key
-  controller and update `app/router.ts` to map that route map explicitly
+- If a top-level leaf grows into a route map, move its handler into the nested route-key controller and update `app/router.ts` to map that route map explicitly
 
 ### Response Rendering And Utilities
 
-- Treat response rendering as action-layer code: modules that return `Response`, choose HTTP status
-  or headers, call `redirect(...)`, or call the local `render(...)` helper belong in `app/actions`
-- Keep `app/actions/render.tsx` small; it should adapt `remix/ui/server` output to
-  `createHtmlResponse(...)`. Route-specific response assembly can live in flat action modules, but
-  directories under `app/actions/` must still match route-map keys
-- Put pure support code in focused `app/utils/<topic>.ts` modules. Formatting, MIME
-  classification, path parsing, sorting, and normalization should be testable without a router,
-  request context, or `Response`, and should not import from `app/actions`, `remix/ui/server`, or
-  `remix/response/*`
-- Do not introduce page-data intermediary shapes only to keep route-specific renderers away from
-  `render(...)`; keep response assembly in actions and extract only the pure helpers
+- Treat response rendering as action-layer code: modules that return `Response`, choose HTTP status or headers, call `redirect(...)`, or call the local `render(...)` helper belong in `app/actions`
+- Keep `app/actions/render.tsx` small; it should adapt `remix/ui/server` output to `createHtmlResponse(...)`. Route-specific response assembly can live in flat action modules, but directories under `app/actions/` must still match route-map keys
+- Put pure support code in focused `app/utils/<topic>.ts` modules. Formatting, MIME classification, path parsing, sorting, and normalization should be testable without a router, request context, or `Response`, and should not import from `app/actions`, `remix/ui/server`, or `remix/response/*`
+- Do not introduce page-data intermediary shapes only to keep route-specific renderers away from `render(...)`; keep response assembly in actions and extract only the pure helpers
 
 ### Layout Anti-Patterns
 
 - Do not create `app/lib/` as a generic dumping ground
-- Do not create `app/components/` as a second shared UI bucket when `app/ui/` already owns that
-  role
+- Do not create `app/components/` as a second shared UI bucket when `app/ui/` already owns that role
 - Do not create `app/controllers/`; Remix app route handlers live under `app/actions/`
 - Do not put shared cross-route UI in `app/actions/`
 - Do not create standalone root action files; put root route actions in `app/actions/controller.tsx`
 - Do not put nested route-map keys in a controller's `actions`
-- Do not register normal app leaf routes directly in `app/router.ts` when they belong in a
-  controller
-- Do not rely on middleware from one controller to protect another controller; map middleware
-  explicitly in each controller that needs it
+- Do not register normal app leaf routes directly in `app/router.ts` when they belong in a controller
+- Do not rely on controller middleware from one controller to protect another controller; add controller middleware explicitly in each controller that needs it
 - Do not put middleware or persistence helpers in `app/utils/` when they have a clearer home
 
 ## Core Remix Rules
 
 - Import from `remix/<subpath>`, never `import { ... } from 'remix'`
-- Treat `app/routes.ts` as the source of truth for URLs. Use `routes.<name>.href(...)` for
-  redirects, links, tests, and internal URL construction
-- Controllers should return explicit `Response` objects, including redirects, 404s, and
-  validation failures. At the route boundary, prefer returning a `Response` for expected outcomes
-  (validation errors, conflicts, not found) over throwing for control flow
-- `router.map(routes, controller)` maps only the direct leaf routes in `routes`; nested route maps
-  must be mapped with their own explicit controllers
-- Model HTTP behavior explicitly. Status codes, headers, redirects, cache rules, and content types
-  are part of the route contract
-- Make the server route correct first. A POST should already return the right HTML, redirect, or
-  error response on its own before `clientEntry(...)` layers interactivity on top
-- Validate input at the boundary using `remix/data-schema` (and `remix/data-schema/form-data` for
-  forms). `parseSafe` makes the failure path a return value instead of an exception
-- Derive `AppContext` from the root middleware stack so `get(Database)`, `get(Session)`,
-  `get(Auth)`, and similar keys stay typed. If the controller never reads from context, it doesn't
-  need the harness
-- Outside actions and controllers, only use `getContext()` when `asyncContext()` is in the
-  middleware stack
-- Remix Component is not React: write `function Name(handle: Handle<Props>) { return () => ... }`,
-  read props from `handle.props`, keep state in setup-scope variables, call `handle.update()`
-  explicitly, and do DOM-sensitive work in event handlers or `queueTask(...)`, not in render
-- Prefer host-element mixins via `mix={mixin(...)}` for behavior and styling instead of inventing
-  custom host prop conventions. Use `mix={[...]}` only when composing multiple mixins
-- Hydrated `clientEntry(...)` props must be serializable. Do not pass functions, class instances, or
-  opaque runtime objects
+- Treat `app/routes.ts` as the source of truth for URLs. Use `routes.<name>.href(...)` for redirects, links, tests, and internal URL construction
+- Controllers should return explicit `Response` objects, including redirects, 404s, and validation failures. At the route boundary, prefer returning a `Response` for expected outcomes (validation errors, conflicts, not found) over throwing for control flow
+- `router.map(routes, controller)` maps only the direct leaf routes in `routes`; nested route maps must be mapped with their own explicit controllers
+- Model HTTP behavior explicitly. Status codes, headers, redirects, cache rules, and content types are part of the route contract
+- Make the server route correct first. A POST should already return the right HTML, redirect, or error response on its own before `clientEntry(...)` layers interactivity on top
+- Validate input at the boundary using `remix/data-schema` (and `remix/data-schema/form-data` for forms). `parseSafe` makes the failure path a return value instead of an exception
+- Derive `AppContext` from the middleware stack so `get(Database)`, `get(Session)`, `get(Auth)`, and similar keys stay typed. If the controller never reads from context, it doesn't need the harness
+- Outside actions and controllers, only use `getContext()` when `asyncContext()` is in the middleware stack
+- Remix Component is not React: write `function Name(handle: Handle<Props>) { return () => ... }`, read props from `handle.props`, keep state in setup-scope variables, call `handle.update()` explicitly, and do DOM-sensitive work in event handlers or `queueTask(...)`, not in render
+- Prefer host-element mixins via `mix={mixin(...)}` for behavior and styling instead of inventing custom host prop conventions. Use `mix={[...]}` only when composing multiple mixins
+- Hydrated `clientEntry(...)` props must be serializable. Do not pass functions, class instances, or opaque runtime objects
 
 ## Security And Session Defaults
 
-- Never ship demo secrets. In non-test environments, require session and provider secrets from the
-  environment and fail fast if they are missing
-- Use hardened cookies: `httpOnly` always, `sameSite` by default, and `secure` when serving over
-  HTTPS
+- Never ship demo secrets. In non-test environments, require session and provider secrets from the environment and fail fast if they are missing
+- Use hardened cookies: `httpOnly` always, `sameSite` by default, and `secure` when serving over HTTPS
 - Regenerate session IDs on login, logout, and privilege changes
-- Use `requireAuth()` to protect authenticated route areas, but still authorize resource ownership
-  inside handlers and data writes
+- Use `requireAuth()` to protect authenticated route areas, but still authorize resource ownership inside handlers and data writes
 - Add CSRF protection when browser forms mutate state using cookie-backed sessions
 - Add CORS only for endpoints that must be called cross-origin. Prefer same-origin by default
 - Prefer JSX or `remix/html-template` for HTML generation so escaping stays correct
@@ -222,20 +166,13 @@ When code could live in multiple places:
 
 ## Testing Defaults
 
-- Prefer server and router tests first. Drive the app with `router.fetch(new Request(...))` and
-  assert on the returned `Response`
-- Keep controller tests shaped like controllers: root route behavior belongs in
-  `app/actions/controller.test.ts(x)`, and nested route-map behavior belongs beside that route-key
-  controller
-- Build a fresh router per test or per suite so sessions, in-memory storage, and database state
-  stay isolated
+- Prefer server and router tests first. Drive the app with `router.fetch(new Request(...))` and assert on the returned `Response`
+- Keep controller tests shaped like controllers: root route behavior belongs in `app/actions/controller.test.ts(x)`, and nested route-map behavior belongs beside that route-key controller
+- Build a fresh router per test or per suite so sessions, in-memory storage, and database state stay isolated
 - Use `routes.<name>.href(...)` in tests so URLs stay coupled to the route contract
-- For auth or session scenarios, use a test cookie and `createMemorySessionStorage()` instead of
-  production storage
-- Co-locate tests for pure `app/utils` helpers beside their modules. Test response behavior through
-  router or controller tests
-- Use component tests only for interactive or DOM-specific behavior. Render with `createRoot(...)`,
-  interact with the real DOM, and call `root.flush()` between steps
+- For auth or session scenarios, use a test cookie and `createMemorySessionStorage()` instead of production storage
+- Co-locate tests for pure `app/utils` helpers beside their modules. Test response behavior through router or controller tests
+- Use component tests only for interactive or DOM-specific behavior. Render with `createRoot(...)`, interact with the real DOM, and call `root.flush()` between steps
 - Prefer one representative behavior test over many repetitive assertion variants
 
 ## Common Mistakes To Avoid
@@ -247,182 +184,100 @@ When code could live in multiple places:
 - Calling `getContext()` without `asyncContext()` in the middleware stack
 - Getting middleware order wrong; fast exits like static files belong early, request enrichment later
 - Skipping boundary validation and trusting raw `FormData`, params, cookies, or external payloads
-- Letting route-local domain errors leak out of the controller. Translate expected outcomes
-  (validation, conflicts, not-found) into the HTTP `Response` the route means to return rather than
-  throwing a custom `Error` subclass and catching it elsewhere
-- Reaching for `createCookie` when a tamper-sensitive or server-managed per-browser fact really
-  wants `remix/session`. If editing the value would be a bug, use a session
-- Building a JSON-only RPC layer when a normal form POST, redirect, or resource route would be
-  simpler. Fetch-from-the-client is a layer on top of sound route behavior, not a replacement for
-  it
-- Treating JSON state endpoints and `<Frame>` reloads as mutually exclusive patterns. Pick the
-  lightest sync mechanism that fits the UX; small widgets may reasonably poll a JSON endpoint
+- Letting route-local domain errors leak out of the controller. Translate expected outcomes (validation, conflicts, not-found) into the HTTP `Response` the route means to return rather than throwing a custom `Error` subclass and catching it elsewhere
+- Reaching for `createCookie` when a tamper-sensitive or server-managed per-browser fact really wants `remix/session`. If editing the value would be a bug, use a session
+- Building a JSON-only RPC layer when a normal form POST, redirect, or resource route would be simpler. Fetch-from-the-client is a layer on top of sound route behavior, not a replacement for it
+- Treating JSON state endpoints and `<Frame>` reloads as mutually exclusive patterns. Pick the lightest sync mechanism that fits the UX; small widgets may reasonably poll a JSON endpoint
 - Assuming authentication is enough without per-resource authorization checks
-- Dropping shared code into vague buckets like `utils.ts`, `helpers.ts`, or `common.ts` when
-  ownership is known
-- Recreating the old `app/controllers` or standalone root action file layout instead of using
-  controllers under `app/actions`
-- Putting nested route-map keys inside a controller `actions` object. Map nested route maps
-  explicitly in `app/router.ts`
-- Treating direct `router.get(...)`/`router.post(...)` registrations as the default app structure
-  instead of using controllers
+- Dropping shared code into vague buckets like `utils.ts`, `helpers.ts`, or `common.ts` when ownership is known
+- Recreating the old `app/controllers` or standalone root action file layout instead of using controllers under `app/actions`
+- Putting nested route-map keys inside a controller `actions` object. Map nested route maps explicitly in `app/router.ts`
+- Treating direct `router.get(...)`/`router.post(...)` registrations as the default app structure instead of using controllers
 - Assuming controller middleware applies to controllers registered for nested route maps
 - Writing only component tests for a feature whose main behavior is really an HTTP route concern
 
 ## Package Map
 
-Use this map to find the right package quickly. Each entry says what the package is for, not just
-what it exports. Open the linked reference file when you need full examples.
+Use this map to find the right package quickly. Each entry says what the package is for, not just what it exports. Open the linked reference file when you need full examples.
 
 ### Routing, Server, and Responses
 
-- `remix/router` — the router itself. Use for `createRouter`, controller and middleware
-  types, and registering routes
-- `remix/routes` — declarative route builders. Use for `route`, `get`, `post`, `put`, `del`,
-  `form`, `resources` when defining `app/routes.ts`
-- `remix/node-fetch-server` — default Node adapter for new apps. Use `createRequestListener` with
-  `node:http`, `node:https`, or `node:http2` in `server.ts` when booting the template-style app
-- `remix/assets` — browser asset server. Use for `createAssetServer` when serving compiled
-  scripts and styles, getting public hrefs, and emitting preloads. Configure a `basePath`, and
-  keep `fileMap` URL patterns relative to it. Shared compiler options such as `target`,
-  `sourceMaps`, `sourceMapSourcePaths`, and `minify` live at the top level
-- `remix/headers` — `SuperHeaders` plus typed header parsers and builders. Use the default export
-  when you want a `Headers` subclass with typed accessors like `headers.contentType`,
-  `headers.cacheControl`, and `headers.setCookie`; use named classes such as `CacheControl`,
-  `ContentDisposition`, and `Vary` when working with individual header values
-- `remix/response/redirect` — `redirect(href, status?)`. Use for the canonical "POST then redirect"
-  pattern and other location changes
-- `remix/response/html` — `createHtmlResponse`. Use when you need an HTML `Response` from a string
-  or stream without rendering through `remix/ui`
-- `remix/response/compress` — `compressResponse`. Use when compressing one-off responses outside
-  the global `compression()` middleware
-- `remix/response/file` — file-download responses. Use for `Content-Disposition: attachment`
-  responses
-- `remix/route-pattern` — low-level URL matching and generation. Use `RoutePattern` or
-  `createMatcher` when working with raw patterns outside the router. `href(...)` encodes pathname
-  and search params for you, and `match(...)` returns decoded params
-- `remix/route-pattern/specificity` — pattern ranking helpers. Use only when building custom
-  matcher or reporting logic outside the normal router/matcher APIs
-- `remix/fetch-proxy` — Fetch-based HTTP proxying. Use to forward a request to another origin; pass
-  `xForwardedHeaders` when the upstream needs forwarded proto, host, and port. It also rewrites
-  proxied `Set-Cookie` domain/path attributes by default
+- `remix/router` — the router itself. Use for `createRouter`, controllers, middleware types, and registering routes
+- `remix/routes` — declarative route builders. Use for `route`, `get`, `post`, `put`, `del`, `form`, `resources` when defining `app/routes.ts`
+- `remix/node-fetch-server` — default Node adapter for new apps. Use `createRequestListener` with `node:http`, `node:https`, or `node:http2` in `server.ts` when booting the template-style app
+- `remix/assets` — browser asset server. Use for `createAssetServer` when serving compiled scripts and styles, getting public hrefs, and emitting preloads. Configure a `basePath`, and keep `fileMap` URL patterns relative to it. Shared compiler options such as `target`, `sourceMaps`, `sourceMapSourcePaths`, and `minify` live at the top level
+- `remix/headers` — `SuperHeaders` plus typed header parsers and builders. Use the default export when you want a `Headers` subclass with typed accessors like `headers.contentType`, `headers.cacheControl`, and `headers.setCookie`; use named classes such as `CacheControl`, `ContentDisposition`, and `Vary` when working with individual header values
+- `remix/response/redirect` — `redirect(href, status?)`. Use for the canonical "POST then redirect" pattern and other location changes
+- `remix/response/html` — `createHtmlResponse`. Use when you need an HTML `Response` from a string or stream without rendering through `remix/ui`
+- `remix/response/compress` — `compressResponse`. Use when compressing one-off responses outside `compression()` middleware
+- `remix/response/file` — file-download responses. Use for `Content-Disposition: attachment` responses
+- `remix/route-pattern` — low-level URL matching and generation. Use `RoutePattern` or `createMatcher` when working with raw patterns outside the router. `href(...)` encodes pathname and search params for you, and `match(...)` returns decoded params
+- `remix/route-pattern/specificity` — pattern ranking helpers. Use only when building custom matcher or reporting logic outside the normal router/matcher APIs
+- `remix/fetch-proxy` — Fetch-based HTTP proxying. Use to forward a request to another origin; pass `xForwardedHeaders` when the upstream needs forwarded proto, host, and port. It also rewrites proxied `Set-Cookie` domain/path attributes by default
 
 ### Data, Validation, and Persistence
 
-- `remix/data-schema` — schema builders for runtime validation. Use for `parse` and `parseSafe`
-  to validate any input that crosses a trust boundary, and `.transform(...)` when validated output
-  should map to a different value or type
-- `remix/data-schema/checks` — common check helpers (`email`, `minLength`, `maxLength`, etc.).
-  Use to compose into a schema
-- `remix/data-schema/coerce` — coercion helpers for strings, numbers, booleans, dates, and ids.
-  Use when input arrives as a string but should be a typed value
-- `remix/data-schema/form-data` — `f.object` and `f.field` for parsing `FormData` directly. Use
-  in actions that read browser forms
-- `remix/data-schema/lazy` — recursive or mutually-referential schemas. Use when a schema needs to
-  refer to itself or another schema that is declared later
-- `remix/data-table` — typed tables and a `Database` interface. Use for `table`, `column`,
-  `createDatabase` when modeling persisted data
-- `remix/data-table/sqlite`, `remix/data-table/postgres`, `remix/data-table/mysql` — adapters.
-  Use to back `createDatabase` with a real engine. SQLite accepts Node, Bun, and compatible
-  synchronous clients with the shared `prepare`/`exec` surface
-- `remix/data-table/migrations` — migration authoring and runners. Use for `createMigration`,
-  `createMigrationRunner`
-- `remix/data-table/migrations/node` — `loadMigrations` from disk. Use in startup scripts that
-  apply migrations
-- `remix/data-table/operators` — query operators such as `inList(...)`. Use when `where` clauses
-  need set or comparison logic
-- `remix/data-table/sql-helpers` — SQL helper utilities for adapter or advanced query work. Avoid
-  this in normal app code unless you are intentionally working below the table/query API
+- `remix/data-schema` — schema builders for runtime validation. Use for `parse` and `parseSafe` to validate any input that crosses a trust boundary, and `.transform(...)` when validated output should map to a different value or type
+- `remix/data-schema/checks` — common check helpers (`email`, `minLength`, `maxLength`, etc.). Use to compose into a schema
+- `remix/data-schema/coerce` — coercion helpers for strings, numbers, booleans, dates, and ids. Use when input arrives as a string but should be a typed value
+- `remix/data-schema/form-data` — `f.object` and `f.field` for parsing `FormData` directly. Use in actions that read browser forms
+- `remix/data-schema/lazy` — recursive or mutually-referential schemas. Use when a schema needs to refer to itself or another schema that is declared later
+- `remix/data-table` — typed tables and a `Database` interface. Use for `table`, `column`, `createDatabase` when modeling persisted data
+- `remix/data-table/sqlite`, `remix/data-table/postgres`, `remix/data-table/mysql` — adapters. Use to back `createDatabase` with a real engine. SQLite accepts Node, Bun, and compatible synchronous clients with the shared `prepare`/`exec` surface
+- `remix/data-table/migrations` — migration authoring and runners. Use for `createMigration`, `createMigrationRunner`
+- `remix/data-table/migrations/node` — `loadMigrations` from disk. Use in startup scripts that apply migrations
+- `remix/data-table/operators` — query operators such as `inList(...)`. Use when `where` clauses need set or comparison logic
+- `remix/data-table/sql-helpers` — SQL helper utilities for adapter or advanced query work. Avoid this in normal app code unless you are intentionally working below the table/query API
 
 ### Auth, Sessions, and Cookies
 
-- `remix/session` — the `Session` object: `get`, `set`, `flash`, `unset`, `regenerateId`. Use for
-  any per-browser state where tampering would be a bug (login, "I submitted this form already",
-  cart, flash messages)
-- `remix/middleware/session` — `session(cookie, storage)`. Use to wire a session cookie and
-  storage backend into the root middleware stack
-- `remix/session-storage/fs`, `remix/session-storage/memory`, `remix/session-storage/cookie` —
-  storage backends. Use `fs-storage` for single-process apps, `memory-storage` for tests,
-  `cookie-storage` for stateless deployments where data fits in a cookie
-- `remix/session-storage/redis` — Redis-backed storage. Use for multi-process or multi-host
-  deployments
+- `remix/session` — the `Session` object: `get`, `set`, `flash`, `unset`, `regenerateId`. Use for any per-browser state where tampering would be a bug (login, "I submitted this form already", cart, flash messages)
+- `remix/middleware/session` — `session(cookie, storage)`. Use to wire a session cookie and storage backend into the middleware stack
+- `remix/session-storage/fs`, `remix/session-storage/memory`, `remix/session-storage/cookie` — storage backends. Use `fs-storage` for single-process apps, `memory-storage` for tests, `cookie-storage` for stateless deployments where data fits in a cookie
+- `remix/session-storage/redis` — Redis-backed storage. Use for multi-process or multi-host deployments
 - `remix/session-storage/memcache` — Memcache-backed storage. Same multi-host use case as Redis
-- `remix/cookie` — `createCookie` for plain signed/unsigned cookies. Use for non-sensitive
-  preferences where the client is allowed to control the value (theme, locale, dismissed banner).
-  For state where tampering matters, prefer `remix/session`
-- `remix/auth` — credentials, OAuth, OIDC, and Atmosphere providers. Use to define how identity is
-  verified, start/finish external login, and refresh stored OAuth/OIDC token bundles with
-  `refreshExternalAuth(...)`
-- `remix/middleware/auth` — `auth({ schemes })`, `requireAuth`, the `Auth` context key. Use to
-  resolve identity into the request context and to gate routes
+- `remix/cookie` — `createCookie` for plain signed/unsigned cookies. Use for non-sensitive preferences where the client is allowed to control the value (theme, locale, dismissed banner). For state where tampering matters, prefer `remix/session`
+- `remix/auth` — credentials, OAuth, OIDC, and Atmosphere providers. Use to define how identity is verified, start/finish external login, and refresh stored OAuth/OIDC token bundles with `refreshExternalAuth(...)`
+- `remix/middleware/auth` — `auth({ schemes })`, `requireAuth`, the `Auth` context key. Use to resolve identity into the request context and to gate routes
 
 ### UI, Hydration, and Browser Behavior
 
-- `remix/ui` — the component runtime: components, core mixins, `clientEntry`, `run`, `<Frame>`,
-  navigation helpers, and `createRoot`. Use for app UI behavior
-- `remix/ui/server` — server rendering: `renderToStream`, `renderToString`. Use in the
-  `app/actions/render.tsx` helper that returns HTML responses
-- `remix/ui/animation` — animation APIs: `animateEntrance`, `animateExit`, `animateLayout`,
-  `spring`, `tween`, and `easings`
-- `remix/ui/<primitive>` — UI primitives, mixins, glyphs, and theme helpers. Current subpaths
-  include `remix/ui/accordion`, `remix/ui/anchor`, `remix/ui/breadcrumbs`, `remix/ui/button`,
-  `remix/ui/combobox`, `remix/ui/glyph`, `remix/ui/listbox`, `remix/ui/menu`,
-  `remix/ui/popover`, `remix/ui/scroll-lock`, `remix/ui/select`, `remix/ui/separator`, and
-  `remix/ui/theme`
+- `remix/ui` — the component runtime: components, core mixins, `clientEntry`, `run`, `<Frame>`, navigation helpers, and `createRoot`. Use for app UI behavior
+- `remix/ui/server` — server rendering: `renderToStream`, `renderToString`. Use in the `app/actions/render.tsx` helper that returns HTML responses
+- `remix/ui/animation` — animation APIs: `animateEntrance`, `animateExit`, `animateLayout`, `spring`, `tween`, and `easings`
+- `remix/ui/<primitive>` — UI primitives, mixins, glyphs, and theme helpers. Current subpaths include `remix/ui/accordion`, `remix/ui/anchor`, `remix/ui/breadcrumbs`, `remix/ui/button`, `remix/ui/combobox`, `remix/ui/glyph`, `remix/ui/listbox`, `remix/ui/menu`, `remix/ui/popover`, `remix/ui/scroll-lock`, `remix/ui/select`, `remix/ui/separator`, and `remix/ui/theme`
 - `remix/ui/test` — component test rendering helpers such as `render`
-- `remix/ui/jsx-runtime` and `remix/ui/jsx-dev-runtime` — JSX transform targets. Configured in
-  `tsconfig.json`, rarely imported directly
-- `remix/html-template` — escaped HTML template literals. Use when generating HTML outside the
-  component system (RSS feeds, email bodies, error pages)
-- `remix/file-storage` — backend-agnostic `File` storage interface. Use as the type bound for
-  upload destinations
-- `remix/file-storage/fs`, `remix/file-storage/memory`, `remix/file-storage/s3` — storage
-  backends. Use to implement an upload destination
+- `remix/ui/jsx-runtime` and `remix/ui/jsx-dev-runtime` — JSX transform targets. Configured in `tsconfig.json`, rarely imported directly
+- `remix/html-template` — escaped HTML template literals. Use when generating HTML outside the component system (RSS feeds, email bodies, error pages)
+- `remix/file-storage` — backend-agnostic `File` storage interface. Use as the type bound for upload destinations
+- `remix/file-storage/fs`, `remix/file-storage/memory`, `remix/file-storage/s3` — storage backends. Use to implement an upload destination
 
 ### Middleware
 
-- `remix/middleware/static` — `staticFiles(dir)`. Use to serve files from `public/` exactly as
-  they exist on disk
-- `remix/middleware/form-data` — `formData()`. Use to parse `FormData` once and expose it via
-  `get(FormData)` instead of calling `await request.formData()` in each action
-- `remix/form-data-parser` — lower-level `parseFormData`, `FileUpload`. Use when implementing
-  custom upload handlers. Upload handler errors propagate directly
-- `remix/multipart-parser` and `remix/multipart-parser/node` — low-level multipart stream parsing.
-  `MultipartPart.headers` is a plain object keyed by lower-case header name; read values with
-  bracket notation such as `part.headers['content-type']`
-- `remix/middleware/compression` — `compression()`. Use globally for text-like responses
-- `remix/middleware/logger` — `logger()`. Use in development for request logs; pass `colors` to
-  force terminal color output on or off
-- `remix/middleware/method-override` — `methodOverride()`. Use when HTML forms need `PUT`,
-  `PATCH`, or `DELETE`
-- `remix/middleware/async-context` — `asyncContext()`, `getContext()`. Use when helpers outside
-  actions need request context without threading it through every call
+- `remix/middleware/static` — `staticFiles(dir)`. Use to serve files from `public/` exactly as they exist on disk
+- `remix/middleware/form-data` — `formData()`. Use to parse `FormData` once and expose it via `get(FormData)` instead of calling `await request.formData()` in each action
+- `remix/form-data-parser` — lower-level `parseFormData`, `FileUpload`. Use when implementing custom upload handlers. Upload handler errors propagate directly
+- `remix/multipart-parser` and `remix/multipart-parser/node` — low-level multipart stream parsing. `MultipartPart.headers` is a plain object keyed by lower-case header name; read values with bracket notation such as `part.headers['content-type']`
+- `remix/middleware/compression` — `compression()`. Use for text-like responses
+- `remix/middleware/logger` — `logger()`. Use in development for request logs; pass `colors` to force terminal color output on or off
+- `remix/middleware/method-override` — `methodOverride()`. Use when HTML forms need `PUT`, `PATCH`, or `DELETE`
+- `remix/middleware/async-context` — `asyncContext()`, `getContext()`. Use when helpers outside actions need request context without threading it through every call
 - `remix/middleware/cors` — `cors(opts?)`. Use for endpoints called cross-origin
-- `remix/middleware/csrf` — `csrf(opts?)`. Use when session-backed forms mutate state and need
-  synchronizer-token CSRF protection
-- `remix/middleware/cop` — cross-origin protection. Use to reject unsafe cross-origin browser
-  requests
+- `remix/middleware/csrf` — `csrf(opts?)`. Use when session-backed forms mutate state and need synchronizer-token CSRF protection
+- `remix/middleware/cop` — cross-origin protection. Use to reject unsafe cross-origin browser requests
 
 ### Test
 
 - `remix/test` — `describe`, `it`, and lifecycle hooks. Use as the test framework
 - `remix/test/cli` — programmatic test runner APIs such as `runRemixTest`
-- `remix/node-fetch-server/test` — `createTestServer` for end-to-end tests that need a real local
-  HTTP server around a Fetch handler
-- `remix/cli` — programmatic Remix CLI API. Use the `remix` executable for project commands such
-  as `remix test`, `remix routes`, `remix doctor`, and `remix version`
-- `remix/assert` — assertion helpers. Use in place of `node:assert` so messages render cleanly
-  in the runner
-- `remix/terminal` — ANSI styles, color detection, style factories, and testable terminal streams.
-  Use for CLIs and terminal output instead of hand-rolled escape sequences
-- `remix/fs` — small filesystem helpers such as `openLazyFile` and `writeFile`. Use in Node-only
-  app or tooling code when you need lazy file responses or safe file writes
-- `remix/lazy-file` — `LazyFile` primitives and byte-range helpers. Use when implementing file or
-  range responses below the higher-level response/file helpers
-- `remix/mime` — content-type and MIME detection helpers. Use instead of maintaining app-local
-  extension maps
-- `remix/tar-parser` — streaming tar parsing. Use for import/export tooling that consumes tar
-  archives
+- `remix/node-fetch-server/test` — `createTestServer` for end-to-end tests that need a real local HTTP server around a Fetch handler
+- `remix/cli` — programmatic Remix CLI API. Use the `remix` executable for project commands such as `remix test`, `remix routes`, `remix doctor`, and `remix version`
+- `remix/assert` — assertion helpers. Use in place of `node:assert` so messages render cleanly in the runner
+- `remix/terminal` — ANSI styles, color detection, style factories, and testable terminal streams. Use for CLIs and terminal output instead of hand-rolled escape sequences
+- `remix/fs` — small filesystem helpers such as `openLazyFile` and `writeFile`. Use in Node-only app or tooling code when you need lazy file responses or safe file writes
+- `remix/lazy-file` — `LazyFile` primitives and byte-range helpers. Use when implementing file or range responses below the higher-level response/file helpers
+- `remix/mime` — content-type and MIME detection helpers. Use instead of maintaining app-local extension maps
+- `remix/tar-parser` — streaming tar parsing. Use for import/export tooling that consumes tar archives
 
 ## Canonical Patterns
 
@@ -558,8 +413,7 @@ export default createController(routes.books, {
 })
 ```
 
-This shape works without JavaScript, returns a `Response` for every outcome, and is ready for
-`clientEntry(...)` interactivity when the UI needs it.
+This shape works without JavaScript, returns a `Response` for every outcome, and is ready for `clientEntry(...)` interactivity when the UI needs it.
 
 ### Build UI from handle props plus render
 
@@ -582,5 +436,4 @@ function Counter(handle: Handle<{ initialCount?: number; label: string }>) {
 }
 ```
 
-Only add `clientEntry(...)` and `run(...)` when the component needs browser interactivity or
-browser-only APIs.
+Only add `clientEntry(...)` and `run(...)` when the component needs browser interactivity or browser-only APIs.

--- a/.agents/skills/remix/references/animate-elements.md
+++ b/.agents/skills/remix/references/animate-elements.md
@@ -2,23 +2,20 @@
 
 ## What This Covers
 
-How to animate insertion, removal, and layout changes of elements. Read this when the task
-involves:
+How to animate insertion, removal, and layout changes of elements. Read this when the task involves:
 
 - Adding entrance, exit, or shared-layout transitions to UI
 - Choosing between spring physics (`spring(...)`) and time-based easing (`tween`)
 - Coordinating CSS transitions with the same easing as JS animations
 - Imperative animation loops via `requestAnimationFrame`
 
-Import animation APIs from `remix/ui/animation`. For the smaller set of animation helpers that
-show up alongside other mixins, see `mixins-styling-events.md`.
+Import animation APIs from `remix/ui/animation`. For the smaller set of animation helpers that show up alongside other mixins, see `mixins-styling-events.md`.
 
 ## Animation Mixins
 
 ### `animateEntrance(config)`
 
-Animates an element when inserted. Config specifies the **starting** style the element animates
-**from**:
+Animates an element when inserted. Config specifies the **starting** style the element animates **from**:
 
 ```tsx
 <div
@@ -32,8 +29,7 @@ Animates an element when inserted. Config specifies the **starting** style the e
 
 ### `animateExit(config)`
 
-Animates an element when removed. Config specifies the **ending** style the element animates
-**to**. The element stays in the DOM until the animation completes:
+Animates an element when removed. Config specifies the **ending** style the element animates **to**. The element stays in the DOM until the animation completes:
 
 ```tsx
 {
@@ -61,8 +57,7 @@ Animates layout changes (position/size) using FLIP-style transforms:
 }
 ```
 
-Options: `duration` (default 200ms), `easing` (default spring snappy), `size` (default true —
-include scale projection for size changes).
+Options: `duration` (default 200ms), `easing` (default spring snappy), `size` (default true — include scale projection for size changes).
 
 ### Combining mixins
 
@@ -91,8 +86,7 @@ include scale projection for size changes).
 
 ## Spring API
 
-Physics-based spring animation. Returns a `SpringIterator` with `duration`, `easing`, and
-`toString()` for CSS.
+Physics-based spring animation. Returns a `SpringIterator` with `duration`, `easing`, and `toString()` for CSS.
 
 ### Presets
 
@@ -159,9 +153,7 @@ for (let t of spring('bouncy')) {
 
 ## Tween API
 
-Generator-based tween for animating values over time with cubic bezier easing. Prefer animation
-mixins or CSS transitions with `spring` for most UI work. Use `tween` for imperative
-`requestAnimationFrame` loops, canvas/WebGL, or non-CSS properties.
+Generator-based tween for animating values over time with cubic bezier easing. Prefer animation mixins or CSS transitions with `spring` for most UI work. Use `tween` for imperative `requestAnimationFrame` loops, canvas/WebGL, or non-CSS properties.
 
 ```tsx
 import { tween, easings } from 'remix/ui/animation'
@@ -183,8 +175,7 @@ function tick(timestamp: number) {
 requestAnimationFrame(tick)
 ```
 
-Built-in easings: `easings.linear`, `easings.ease`, `easings.easeIn`, `easings.easeOut`,
-`easings.easeInOut`.
+Built-in easings: `easings.linear`, `easings.ease`, `easings.easeIn`, `easings.easeOut`, `easings.easeInOut`.
 
 ## Practical Guidance
 

--- a/.agents/skills/remix/references/assets-and-browser-modules.md
+++ b/.agents/skills/remix/references/assets-and-browser-modules.md
@@ -4,25 +4,18 @@
 
 How to serve browser scripts and styles from source. Read this when the task involves:
 
-- Configuring `createAssetServer` (`basePath`, `fileMap`, `allow`, `deny`, fingerprinting,
-  compiler options)
-- Choosing between `staticFiles()` for already-built files and `createAssetServer()` for source
-  assets that need import rewriting, preloads, or fingerprinted URLs
+- Configuring `createAssetServer` (`basePath`, `fileMap`, `allow`, `deny`, fingerprinting, compiler options)
+- Choosing between `staticFiles()` for already-built files and `createAssetServer()` for source assets that need import rewriting, preloads, or fingerprinted URLs
 - Generating script URLs or `<link rel="modulepreload">` tags for a client entry
 - Keeping server-only files out of the browser via `deny` rules
 
-For routing the URL namespace itself, see `routing-and-controllers.md`. For client entry
-hydration, see `hydration-frames-navigation.md`.
+For routing the URL namespace itself, see `routing-and-controllers.md`. For client entry hydration, see `hydration-frames-navigation.md`.
 
 ## When To Reach For It
 
-Use `remix/assets` when the app serves browser JavaScript, TypeScript, or CSS from source files.
-This is the right tool for client entrypoints, browser-only helpers, styles under `app/assets/`,
-and monorepo code that should be compiled and served under a public URL namespace.
+Use `remix/assets` when the app serves browser JavaScript, TypeScript, or CSS from source files. This is the right tool for client entrypoints, browser-only helpers, styles under `app/assets/`, and monorepo code that should be compiled and served under a public URL namespace.
 
-Use `staticFiles()` for files that already exist on disk exactly as they should be served. Use
-`createAssetServer()` for source scripts or styles that need rewriting, dependency scanning,
-preloads, sourcemaps, or fingerprinted URLs.
+Use `staticFiles()` for files that already exist on disk exactly as they should be served. Use `createAssetServer()` for source scripts or styles that need rewriting, dependency scanning, preloads, sourcemaps, or fingerprinted URLs.
 
 ## Default Pattern
 
@@ -66,22 +59,16 @@ export default createController(routes, {
 ## Rules
 
 - Treat `allow` and `deny` as the security boundary for browser-reachable source files.
-- Add a `deny` list for server-only modules such as `*.server.*`, private config, or other files
-  that should never be exposed.
+- Add a `deny` list for server-only modules such as `*.server.*`, private config, or other files that should never be exposed.
 - Set `rootDir` explicitly in monorepos so relative paths resolve from the intended project root.
 - `basePath` is the public URL namespace handled by the asset server.
-- `fileMap` keys are URL patterns relative to `basePath`, and values are root-relative file path
-  patterns. They use `route-pattern` syntax on both sides.
-- Keep the same wildcard params on both sides of a `fileMap` entry so import rewriting can map
-  source files back to public URLs.
-- CSS files are compiled and served alongside scripts. Local CSS `@import` rules are rewritten and
-  fingerprinted with the same asset server routing rules.
+- `fileMap` keys are URL patterns relative to `basePath`, and values are root-relative file path patterns. They use `route-pattern` syntax on both sides.
+- Keep the same wildcard params on both sides of a `fileMap` entry so import rewriting can map source files back to public URLs.
+- CSS files are compiled and served alongside scripts. Local CSS `@import` rules are rewritten and fingerprinted with the same asset server routing rules.
 
 ## Rendering HTML
 
-Use `getHref()` when you need the public URL for one module, and `getPreloads()` when you want
-`<link rel="modulepreload">` tags or `Link` headers for one or more entrypoints and their
-dependencies.
+Use `getHref()` when you need the public URL for one module, and `getPreloads()` when you want `<link rel="modulepreload">` tags or `Link` headers for one or more entrypoints and their dependencies.
 
 ```typescript
 let entryHref = await assetServer.getHref('app/assets/entry.ts')
@@ -90,10 +77,7 @@ let preloads = await assetServer.getPreloads(['app/assets/entry.ts'])
 
 Use this when rendering documents or layouts that boot browser behavior with a known client entry.
 
-When resolving hydrated client entries during server rendering, pass the source entry ID from
-`clientEntry(import.meta.url, ...)` to `getHref()` inside `resolveClientEntry`. Keep export-name
-resolution in that render helper, and avoid hard-coding public asset URLs in source-owned component
-modules.
+When resolving hydrated client entries during server rendering, pass the source entry ID from `clientEntry(import.meta.url, ...)` to `getHref()` inside `resolveClientEntry`. Keep export-name resolution in that render helper, and avoid hard-coding public asset URLs in source-owned component modules.
 
 ## Development vs Deployment
 
@@ -116,15 +100,12 @@ Fingerprinting assumes files on disk are stable and requires `watch: false`.
 - `minify` for production minification of scripts and styles
 - `sourceMaps` for `'external'` or `'inline'` source maps for scripts and styles
 - `sourceMapSourcePaths` for `'url'` or `'absolute'` source map paths
-- `target` as an object for shared browser targets and script-only ECMAScript output, such as
-  `{ es: '2020', chrome: '109', safari: '16.4' }`
+- `target` as an object for shared browser targets and script-only ECMAScript output, such as `{ es: '2020', chrome: '109', safari: '16.4' }`
 - `scripts.define` to replace globals such as `process.env.NODE_ENV`
 - `scripts.external` to leave specific script imports untouched
 
-Do not nest shared compiler options under `scripts`. Use top-level `minify`, `sourceMaps`,
-`sourceMapSourcePaths`, and `target` so they apply to styles as well as scripts.
+Do not nest shared compiler options under `scripts`. Use top-level `minify`, `sourceMaps`, `sourceMapSourcePaths`, and `target` so they apply to styles as well as scripts.
 
 ## Lifecycle
 
-If the asset server is long-lived and watching the file system, call `await assetServer.close()`
-when shutting down dev servers or disposing tests.
+If the asset server is long-lived and watching the file system, call `await assetServer.close()` when shutting down dev servers or disposing tests.

--- a/.agents/skills/remix/references/auth-and-sessions.md
+++ b/.agents/skills/remix/references/auth-and-sessions.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-How to remember things about a browser between requests and how to identify a user. Read this when
-the task involves:
+How to remember things about a browser between requests and how to identify a user. Read this when the task involves:
 
 - Storing per-browser state across requests (login, cart, "I have submitted this form")
 - Adding a credentials login flow or an OAuth provider
@@ -11,23 +10,15 @@ the task involves:
 - Reading or writing `Session`, `Auth`, or other identity-related context values
 - Logging in, logging out, or rotating session IDs
 
-For raw cookies that are not session-backed (theme, locale, dismissed-banner), see
-`createCookie` in this file plus the broader `Package Map` in `SKILL.md`.
+For raw cookies that are not session-backed (theme, locale, dismissed-banner), see `createCookie` in this file plus the broader `Package Map` in `SKILL.md`.
 
 ## Sessions vs Plain Cookies
 
-Reach for `remix/session` when state is sensitive, must be tamper-resistant, or represents the
-identity of a request: who is logged in, which form a browser already submitted, what items are in
-a cart. Sessions sign or encrypt their backing cookie with a server-held secret and give you a
-typed `Session` object you can `get`, `set`, `flash`, `unset`, and `regenerateId`.
+Reach for `remix/session` when state is sensitive, must be tamper-resistant, or represents the identity of a request: who is logged in, which form a browser already submitted, what items are in a cart. Sessions sign or encrypt their backing cookie with a server-held secret and give you a typed `Session` object you can `get`, `set`, `flash`, `unset`, and `regenerateId`.
 
-Reach for `remix/cookie` directly when the browser is allowed to carry the value and the server
-does not need session semantics. This often means preferences (theme, locale, dismissed banner),
-but a signed cookie can also be fine for small low-risk values where you truly only need one
-cookie-shaped fact and do not need `Session` helpers.
+Reach for `remix/cookie` directly when the browser is allowed to carry the value and the server does not need session semantics. This often means preferences (theme, locale, dismissed banner), but a signed cookie can also be fine for small low-risk values where you truly only need one cookie-shaped fact and do not need `Session` helpers.
 
-If a malicious user editing the value would be a bug, or if the value needs server-managed
-lifecycle, reach for a session.
+If a malicious user editing the value would be a bug, or if the value needs server-managed lifecycle, reach for a session.
 
 ### Quick chooser
 
@@ -60,9 +51,7 @@ export let sessionCookie = createCookie('session', {
 })
 ```
 
-The cookie should always be `httpOnly`, default to `sameSite: 'Lax'`, and be `secure` in
-production. Demo defaults like `'s3cr3t'` are fine in tests but should never reach production —
-fail fast when the secret is missing.
+The cookie should always be `httpOnly`, default to `sameSite: 'Lax'`, and be `secure` in production. Demo defaults like `'s3cr3t'` are fine in tests but should never reach production — fail fast when the secret is missing.
 
 ### Create session storage
 
@@ -117,9 +106,7 @@ async function handler({ get }) {
 
 ### Sessions for non-auth state
 
-Sessions are not just for login. They are the right place to store any tamper-sensitive
-per-browser fact: which form a browser already submitted, how many free actions are left in a
-trial, which feature flags a tester opted into, what items are in a cart.
+Sessions are not just for login. They are the right place to store any tamper-sensitive per-browser fact: which form a browser already submitted, how many free actions are left in a trial, which feature flags a tester opted into, what items are in a cart.
 
 ```typescript
 async function submit({ get }) {
@@ -141,10 +128,7 @@ async function submit({ get }) {
 }
 ```
 
-Notice that there is no manual `Set-Cookie` plumbing in the action — the session middleware handles
-that, and the handler returns an ordinary `Response`. Per-browser state enforced this way is still
-bypassable by clearing cookies; if the guarantee needs to survive that, you also need an account
-(see auth providers below).
+Notice that there is no manual `Set-Cookie` plumbing in the action — the session middleware handles that, and the handler returns an ordinary `Response`. Per-browser state enforced this way is still bypassable by clearing cookies; if the guarantee needs to survive that, you also need an account (see auth providers below).
 
 ## Auth Middleware
 
@@ -296,9 +280,7 @@ let atmosphereProvider = createAtmosphereAuthProvider({
 })
 ```
 
-For Atmosphere-compatible atproto OAuth, create the provider once, call
-`atmosphereProvider.prepare(handleOrDid)` before `startExternalAuth(...)`, then pass the same
-module-scope provider to `finishExternalAuth(...)` and `refreshExternalAuth(...)`.
+For Atmosphere-compatible atproto OAuth, create the provider once, call `atmosphereProvider.prepare(handleOrDid)` before `startExternalAuth(...)`, then pass the same module-scope provider to `finishExternalAuth(...)` and `refreshExternalAuth(...)`.
 
 ### OAuth controller
 
@@ -336,10 +318,7 @@ export default createController(routes.auth.google, {
 
 ### Refresh stored provider tokens
 
-Use `refreshExternalAuth(provider, tokens)` when an app has stored OAuth/OIDC tokens and needs a
-fresh access token from a refresh token. Built-in OIDC providers, X, and Atmosphere support
-refresh-token exchange. If the provider does not rotate the refresh token, the refreshed bundle
-preserves the current one.
+Use `refreshExternalAuth(provider, tokens)` when an app has stored OAuth/OIDC tokens and needs a fresh access token from a refresh token. Built-in OIDC providers, X, and Atmosphere support refresh-token exchange. If the provider does not rotate the refresh token, the refreshed bundle preserves the current one.
 
 ```typescript
 async function refreshGoogleTokens({ get }) {
@@ -356,9 +335,9 @@ async function refreshGoogleTokens({ get }) {
 
 ## Protecting Routes
 
-### Controller-level protection
+### Controller middleware protection
 
-Apply `requireAuth()` to every action in one controller:
+Apply `requireAuth()` as controller middleware to every action in one controller:
 
 ```typescript
 import { createController } from 'remix/router'
@@ -410,7 +389,7 @@ export default createController(routes.admin, {
 })
 ```
 
-### Action-level protection
+### Action middleware protection
 
 Apply middleware to a single route:
 

--- a/.agents/skills/remix/references/component-model.md
+++ b/.agents/skills/remix/references/component-model.md
@@ -2,18 +2,14 @@
 
 ## What This Covers
 
-How a Remix Component is shaped and how its state, lifecycle, and updates behave. Read this when
-the task involves:
+How a Remix Component is shaped and how its state, lifecycle, and updates behave. Read this when the task involves:
 
 - Writing a component (`handle` plus render function)
 - Managing component-local state, derived values, or post-render DOM work
-- Using `handle.props`, `handle.update()`, `handle.queueTask()`, `handle.signal`, `handle.id`, or
-  `handle.context`
+- Using `handle.props`, `handle.update()`, `handle.queueTask()`, `handle.signal`, `handle.id`, or `handle.context`
 - Listening to global events with cleanup tied to the component lifecycle
 
-For host-element behavior (event handlers, styles, refs, animations), see
-`mixins-styling-events.md`. For browser hydration, frames, and navigation, see
-`hydration-frames-navigation.md`.
+For host-element behavior (event handlers, styles, refs, animations), see `mixins-styling-events.md`. For browser hydration, frames, and navigation, see `hydration-frames-navigation.md`.
 
 ## Phases
 
@@ -22,8 +18,7 @@ A component has two phases:
 1. **Setup phase** — runs once when the component is created
 2. **Render phase** — returned zero-argument function runs on initial render and every update
 
-The component shape is `function Component(handle: Handle<Props>) { return () => ... }`. Props are
-available as `handle.props` in setup scope and are updated before every render.
+The component shape is `function Component(handle: Handle<Props>) { return () => ... }`. Props are available as `handle.props` in setup scope and are updated before every render.
 
 ```tsx
 import { on, type Handle } from 'remix/ui'
@@ -46,9 +41,7 @@ function Counter(handle: Handle<{ initialCount?: number; label: string }>) {
 
 ## Props
 
-Components receive all JSX props through `handle.props`. The object identity is stable for the
-component lifetime, and its values are updated before each render. Put initialization inputs on
-normal JSX props and read them from `handle.props`:
+Components receive all JSX props through `handle.props`. The object identity is stable for the component lifetime, and its values are updated before each render. Put initialization inputs on normal JSX props and read them from `handle.props`:
 
 ```tsx
 function Timer(handle: Handle<{ initialSeconds: number; paused?: boolean }>) {
@@ -60,9 +53,7 @@ function Timer(handle: Handle<{ initialSeconds: number; paused?: boolean }>) {
 // Usage: <Timer initialSeconds={60} paused={false} />
 ```
 
-Because `handle.props` is stable, destructuring `let { props } = handle` is safe when helpers need
-to read current values later. Destructuring individual prop values is only a snapshot; prefer
-`handle.props.name` inside callbacks and render output when values can change.
+Because `handle.props` is stable, destructuring `let { props } = handle` is safe when helpers need to read current values later. Destructuring individual prop values is only a snapshot; prefer `handle.props.name` inside callbacks and render output when values can change.
 
 ## State Rules
 
@@ -87,8 +78,7 @@ function TodoList(handle: Handle) {
 
 ### `handle.update()`
 
-Schedules a rerender. Returns a promise that resolves with an `AbortSignal` after the update
-completes. Await it when you need the updated DOM before follow-up work:
+Schedules a rerender. Returns a promise that resolves with an `AbortSignal` after the update completes. Await it when you need the updated DOM before follow-up work:
 
 ```tsx
 on('click', async () => {
@@ -101,9 +91,7 @@ on('click', async () => {
 
 ### `handle.queueTask(task)`
 
-Schedules a task to run after the next update. The task receives an `AbortSignal` that aborts when
-the component re-renders or is removed. Use for post-render DOM work, reactive data loading, or
-hydration-sensitive setup:
+Schedules a task to run after the next update. The task receives an `AbortSignal` that aborts when the component re-renders or is removed. Use for post-render DOM work, reactive data loading, or hydration-sensitive setup:
 
 ```tsx
 let data = null
@@ -138,8 +126,7 @@ return () => {
 }
 ```
 
-Avoid creating intermediate state just to trigger `queueTask`. Do the work directly in the handler
-or the queued task.
+Avoid creating intermediate state just to trigger `queueTask`. Do the work directly in the handler or the queued task.
 
 ### `handle.signal`
 
@@ -191,8 +178,7 @@ Context for ancestor/descendant communication. See the context section below.
 
 ## Context
 
-Use `handle.context.set()` to provide values and `handle.context.get(Provider)` to consume them.
-`set()` does **not** trigger updates — call `handle.update()` if the tree needs to rerender.
+Use `handle.context.set()` to provide values and `handle.context.get(Provider)` to consume them. `set()` does **not** trigger updates — call `handle.update()` if the tree needs to rerender.
 
 ```tsx
 function ThemeProvider(handle: Handle<{ children?: RemixNode }, { theme: 'light' | 'dark' }>) {
@@ -264,8 +250,7 @@ function ThemedContent(handle: Handle) {
 
 ## Global Events
 
-Use `addEventListeners(target, handle.signal, listeners)` to listen to global targets with
-automatic cleanup when the component disconnects:
+Use `addEventListeners(target, handle.signal, listeners)` to listen to global targets with automatic cleanup when the component disconnects:
 
 ```tsx
 import { addEventListeners, type Handle } from 'remix/ui'

--- a/.agents/skills/remix/references/create-mixins.md
+++ b/.agents/skills/remix/references/create-mixins.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-How to author your own reusable host-element behavior with `createMixin`. Read this when the task
-involves:
+How to author your own reusable host-element behavior with `createMixin`. Read this when the task involves:
 
 - Combining multiple low-level events or DOM hooks into one semantic mixin
 - Dispatching custom DOM events from a host node
@@ -14,9 +13,7 @@ For the built-in mixins most code should use, see `mixins-styling-events.md`.
 
 Use `createMixin` from `remix/ui` to author reusable host-element behavior.
 
-Most app code should use built-in core mixins (`on`, `css`, `ref`, `link`, `attrs`) and animation
-mixins from `remix/ui/animation`. Create custom mixins when combining multiple low-level events
-into one semantic event, or when the pattern is reused across components.
+Most app code should use built-in core mixins (`on`, `css`, `ref`, `link`, `attrs`) and animation mixins from `remix/ui/animation`. Create custom mixins when combining multiple low-level events into one semantic event, or when the pattern is reused across components.
 
 ## Core Semantics
 
@@ -24,8 +21,7 @@ into one semantic event, or when the pattern is reused across components.
 2. `insert` is the host-node availability point for imperative setup.
 3. `remove` is teardown for that same lifecycle.
 4. `queueTask` runs post-commit and receives `(node, signal)` for mixins.
-5. Mixin render functions should stay pure; side effects belong in `insert`, `remove`, or queued
-   work.
+5. Mixin render functions should stay pure; side effects belong in `insert`, `remove`, or queued work.
 
 ```tsx
 import { createMixin } from 'remix/ui'
@@ -71,8 +67,7 @@ let withFocus = createMixin<HTMLElement>((handle) => {
 
 ## Custom Event Mixins
 
-Create event mixins when you combine multiple low-level events into one semantic custom event that
-is reused across components.
+Create event mixins when you combine multiple low-level events into one semantic custom event that is reused across components.
 
 1. Namespace custom event names (`myapp:*`) to avoid collisions.
 2. Extend `Event` with the data consumers need.

--- a/.agents/skills/remix/references/data-and-validation.md
+++ b/.agents/skills/remix/references/data-and-validation.md
@@ -2,16 +2,14 @@
 
 ## What This Covers
 
-How input becomes a value the app trusts, and how that value reaches storage. Read this when the
-task involves:
+How input becomes a value the app trusts, and how that value reaches storage. Read this when the task involves:
 
 - Defining database tables, columns, relations, and migrations
 - Querying or mutating persisted data with `Database`
 - Parsing and validating user input from forms, query strings, or external payloads
 - Choosing between schema-level checks, table validation hooks, and migration-level constraints
 
-For where validation runs in the request lifecycle, see `routing-and-controllers.md`. For session
-or identity-bound writes, see `auth-and-sessions.md`.
+For where validation runs in the request lifecycle, see `routing-and-controllers.md`. For session or identity-bound writes, see `auth-and-sessions.md`.
 
 ## Table Definitions (`remix/data-table`)
 
@@ -65,22 +63,16 @@ export type OrderWithItems = TableRowWith<typeof orders, 'items'>
 | `c.uuid()`                    | UUID / TEXT        |
 | `c.varchar(length)`           | VARCHAR            |
 
-Column modifiers: `.primaryKey()`, `.autoIncrement()`, `.notNull()`, `.unique()`,
-`.references(table, column, fkName?)`, `.onDelete(action)`, `.default(value)`.
+Column modifiers: `.primaryKey()`, `.autoIncrement()`, `.notNull()`, `.unique()`, `.references(table, column, fkName?)`, `.onDelete(action)`, `.default(value)`.
 
 Composite primary keys go on the table option, not the column: `primaryKey: ['order_id', 'book_id']`.
 
 ### Schema vs migrations
 
-Column modifiers describe SQL constraints — the source of truth for them is your **migration**
-files, where they generate the actual DDL. Runtime `table(...)` definitions in `app/data/schema.ts`
-can use the same modifiers, or they can stay minimal (`c.integer()`, `c.text()`, ...) since the
-runtime only needs the column shape and validation hooks. Two valid patterns:
+Column modifiers on runtime `table(...)` definitions in `app/data/schema.ts` describe app-facing column metadata. They do not create or update database tables by themselves. The source of truth for actual DDL and constraints is your hand-written SQL migration files. Two valid patterns:
 
-- **Modifiers in both** — schema and migrations stay in sync visually; useful when you want
-  schema-level docs.
-- **Bare columns in schema, full modifiers in migrations** — schema describes what the app reads
-  and writes; migrations own the DDL and constraints.
+- **Mirror constraints in schema and SQL** — table definitions stay useful as schema-level docs, and migrations still own the actual DDL.
+- **Bare columns in schema, constraints in SQL** — schema describes what the app reads and writes; migrations own the DDL and constraints.
 
 Pick one and apply it consistently across the app.
 
@@ -88,8 +80,7 @@ Pick one and apply it consistently across the app.
 
 Tables can define validation and lifecycle hooks:
 
-- `validate` runs before `create` and `update` writes and should return either `{ value }` or
-  `{ issues }`
+- `validate` runs before `create` and `update` writes and should return either `{ value }` or `{ issues }`
 - `beforeWrite` can normalize or veto `create`/`update` values
 - `afterWrite` observes completed `create`/`update` operations
 - `beforeDelete` and `afterDelete` observe or veto deletes
@@ -135,9 +126,7 @@ let adapter = createSqliteDatabaseAdapter(sqlite)
 export let db = createDatabase(adapter)
 ```
 
-`createSqliteDatabaseAdapter` accepts synchronous SQLite clients with a shared `prepare`/`exec`
-surface, including Node's `node:sqlite`, Bun's `bun:sqlite`, and compatible clients. Use whichever
-client fits the runtime instead of assuming `better-sqlite3` is required.
+`createSqliteDatabaseAdapter` accepts synchronous SQLite clients with a shared `prepare`/`exec` surface, including Node's `node:sqlite`, Bun's `bun:sqlite`, and compatible clients. Use whichever client fits the runtime instead of assuming `better-sqlite3` is required.
 
 ### Database middleware
 
@@ -195,45 +184,50 @@ let featured = await db.findMany(books, {
 
 ## Migrations
 
+Migrations are plain SQL files. Each migration is a directory named `YYYYMMDDHHmmss_<slug>/` containing a hand-written `up.sql` (required) and an optional `down.sql` (omit for irreversible migrations).
+
+```txt
+db/
+  migrations/
+    20260228090000_create_users/
+      up.sql
+      down.sql
+    20260301083000_add_books_search_index/
+      up.sql
+```
+
 ### Writing migrations
 
-```typescript
-import { column as c, createMigration } from 'remix/data-table/migrations'
-import { table } from 'remix/data-table'
+Write standard SQL in `up.sql` and `down.sql`:
 
-export default createMigration({
-  async up({ schema }) {
-    let users = table({
-      name: 'users',
-      columns: {
-        id: c.integer().primaryKey().autoIncrement(),
-        email: c.text().notNull().unique(),
-        name: c.text().notNull(),
-      },
-    })
-    await schema.createTable(users)
-    await schema.createIndex(users, 'email', { name: 'users_email_idx', unique: true })
-  },
+```sql
+-- up.sql
+create table users (
+  id integer primary key autoincrement,
+  email text not null unique,
+  name text not null
+);
 
-  async down({ schema }) {
-    await schema.dropTable('users')
-  },
-})
+create index users_email_idx on users (email);
 ```
 
-Migrations can also import table definitions from the app schema to avoid duplication:
-
-```typescript
-import { createMigration } from 'remix/data-table/migrations'
-import { users, authAccounts } from '../../app/data/schema.ts'
-
-export default createMigration({
-  async up({ schema }) {
-    await schema.createTable(users)
-    await schema.createTable(authAccounts)
-  },
-})
+```sql
+-- down.sql
+drop table if exists users;
 ```
+
+Do **not** import app code (e.g. `app/data/schema.ts`) into migration files. Migrations must be stable, immutable artifacts — importing live schema definitions creates drift between what the migration meant when it was written and what it does when replayed later. SQL files guarantee stability because they cannot import anything.
+
+### Transaction modes
+
+Migrations run inside a transaction by default (when the adapter supports transactional DDL). Override per migration with a directive comment in `up.sql`:
+
+```sql
+-- data-table/transaction: none
+create index concurrently users_email_idx on users (email);
+```
+
+Modes: `auto` (default — wrap when supported), `required` (wrap; throw if unsupported), `none` (never wrap).
 
 ### Running migrations
 
@@ -246,15 +240,11 @@ let runner = createMigrationRunner(adapter, migrations)
 await runner.up()
 ```
 
-### Migration file naming
-
-Name migration files with a timestamp prefix: `20260228090000_create_users.ts`. Place them in
-`db/migrations/`.
+The runner checksums each `up.sql` and detects drift if a previously applied migration changes. Use `runner.status()` to inspect applied/pending/drifted state, and `runner.down()` to revert.
 
 ## Input Validation (`remix/data-schema`)
 
-Use `data-schema` to validate user input (forms, query params, API payloads). This is separate from
-table-level `validate` hooks which run at persistence.
+Use `data-schema` to validate user input (forms, query params, API payloads). This is separate from table-level `validate` hooks which run at persistence.
 
 ### Schema builders
 
@@ -295,9 +285,7 @@ let { name, email, password } = s.parse(signupSchema, formData)
 
 There are two ways to get a `FormData` value inside an action.
 
-The recommended way: register `formData()` middleware in the root stack and read with
-`get(FormData)`. The body is parsed once per request, and the typed `FormData` value flows through
-the context system. This also lets `methodOverride()` and CSRF middleware work uniformly.
+The recommended way: register `formData()` middleware in the root stack and read with `get(FormData)`. The body is parsed once per request, and the typed `FormData` value flows through the context system. This also lets `methodOverride()` and CSRF middleware work uniformly.
 
 ```typescript
 import { formData } from 'remix/middleware/form-data'
@@ -310,15 +298,11 @@ let router = createRouter({
 let parsed = s.parseSafe(signupSchema, get(FormData))
 ```
 
-The fallback: `await request.formData()` directly. This works without middleware and is fine for
-small one-off cases, but it bypasses the context system, runs once per call site, and doesn't
-compose with middleware that depends on parsed form fields.
+The fallback: `await request.formData()` directly. This works without middleware and is fine for small one-off cases, but it bypasses the context system, runs once per call site, and doesn't compose with middleware that depends on parsed form fields.
 
 ### Safe parsing
 
-`s.parse` throws on invalid input. `s.parseSafe` returns a tagged result and is usually what an
-action wants, since validation failure is an expected outcome (re-render the form with errors)
-rather than an exception:
+`s.parse` throws on invalid input. `s.parseSafe` returns a tagged result and is usually what an action wants, since validation failure is an expected outcome (re-render the form with errors) rather than an exception:
 
 ```typescript
 let result = s.parseSafe(signupSchema, get(FormData))
@@ -328,13 +312,11 @@ if (!result.success) {
 let { name, email, password } = result.value
 ```
 
-Returning a `Response` for validation failures keeps the route contract honest: the same action
-returns 200 on success, 400 with errors on bad input, no out-of-band exception flow.
+Returning a `Response` for validation failures keeps the route contract honest: the same action returns 200 on success, 400 with errors on bad input, no out-of-band exception flow.
 
 ### Transforming validated output
 
-Use `.transform(...)` when a schema should validate one shape but return another value or output
-type. Transforms run after validation and compose with `.pipe(...)` and `.refine(...)`:
+Use `.transform(...)` when a schema should validate one shape but return another value or output type. Transforms run after validation and compose with `.pipe(...)` and `.refine(...)`:
 
 ```typescript
 import * as coerce from 'remix/data-schema/coerce'
@@ -356,14 +338,9 @@ let { page, q } = s.parse(pageSchema, formData)
 
 Avoid these shapes when reading and validating input:
 
-- **Raw `formData.get('name')` plus an `if (typeof name !== 'string')` guard**, then a thrown
-  custom error. This reinvents what `data-schema` already does, loses the typed result, and
-  pushes error translation into a `try/catch` instead of a return value.
-- **Letting route-local domain errors leak out of the action.** Translate expected outcomes (bad
-  input, missing record, duplicate entry) into the `Response` the route means to return instead of
-  throwing a custom `Error` subclass with a `status` field and catching it later.
-- **Trusting `params`, query strings, or external payloads without a schema.** Anything that
-  crosses a trust boundary should be parsed before it reaches business logic.
+- **Raw `formData.get('name')` plus an `if (typeof name !== 'string')` guard**, then a thrown custom error. This reinvents what `data-schema` already does, loses the typed result, and pushes error translation into a `try/catch` instead of a return value.
+- **Letting route-local domain errors leak out of the action.** Translate expected outcomes (bad input, missing record, duplicate entry) into the `Response` the route means to return instead of throwing a custom `Error` subclass with a `status` field and catching it later.
+- **Trusting `params`, query strings, or external payloads without a schema.** Anything that crosses a trust boundary should be parsed before it reaches business logic.
 
 ### Common patterns
 

--- a/.agents/skills/remix/references/hydration-frames-navigation.md
+++ b/.agents/skills/remix/references/hydration-frames-navigation.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-How server-rendered UI becomes interactive in the browser, and how the page updates without a full
-navigation. Read this when the task involves:
+How server-rendered UI becomes interactive in the browser, and how the page updates without a full navigation. Read this when the task involves:
 
 - Marking a component for client-side hydration with `clientEntry`
 - Booting the client runtime with `run`
@@ -12,19 +11,13 @@ navigation. Read this when the task involves:
 - Server rendering with `renderToStream` or `renderToString`
 - Managing the document `<head>`
 
-For component-local state and updates, see `component-model.md`. For host-element behavior and
-events, see `mixins-styling-events.md`.
+For component-local state and updates, see `component-model.md`. For host-element behavior and events, see `mixins-styling-events.md`.
 
 ## Server First, Then Hydrate
 
-Make the server route correct before adding `clientEntry(...)`. A POST should already do the right
-thing on its own — return HTML, a redirect, or an error response — and a GET should already render
-the page the user expects. `clientEntry` exists to layer interactivity on top of UI that already
-works without it.
+Make the server route correct before adding `clientEntry(...)`. A POST should already do the right thing on its own — return HTML, a redirect, or an error response — and a GET should already render the page the user expects. `clientEntry` exists to layer interactivity on top of UI that already works without it.
 
-When server state changes after a mutation, prefer reloading a `<Frame>` when the UI region already
-maps cleanly to a server-rendered route. Frames re-fetch the same route, so the rendering logic
-stays in one place and the client does not need a parallel "state" API.
+When server state changes after a mutation, prefer reloading a `<Frame>` when the UI region already maps cleanly to a server-rendered route. Frames re-fetch the same route, so the rendering logic stays in one place and the client does not need a parallel "state" API.
 
 ```tsx
 on('submit', async (event, signal) => {
@@ -39,15 +32,11 @@ on('submit', async (event, signal) => {
 })
 ```
 
-Use polling or a small JSON state endpoint when the data changes outside this page, or when a tiny
-shared widget would be heavier to model as a frame. Pick the lightest sync mechanism that preserves
-clear ownership of rendering logic.
+Use polling or a small JSON state endpoint when the data changes outside this page, or when a tiny shared widget would be heavier to model as a frame. Pick the lightest sync mechanism that preserves clear ownership of rendering logic.
 
 ## Client Entries
 
-Use `clientEntry` to mark a component for client-side hydration. In source-served apps, prefer the
-source module's `import.meta.url` as the entry ID and let server rendering map it to the public
-asset URL:
+Use `clientEntry` to mark a component for client-side hydration. In source-served apps, prefer the source module's `import.meta.url` as the entry ID and let server rendering map it to the public asset URL:
 
 ```tsx
 import { clientEntry, on, type Handle } from 'remix/ui'
@@ -76,9 +65,7 @@ export const Counter = clientEntry(
 )
 ```
 
-On the server, provide `resolveClientEntry` to `renderToStream(...)` so source file URLs become
-browser-loadable asset URLs. Keep this resolution in the render helper so component modules do not
-hard-code deployment-specific asset paths:
+On the server, provide `resolveClientEntry` to `renderToStream(...)` so source file URLs become browser-loadable asset URLs. Keep this resolution in the render helper so component modules do not hard-code deployment-specific asset paths:
 
 ```tsx
 let stream = renderToStream(<App />, {
@@ -96,21 +83,15 @@ let stream = renderToStream(<App />, {
 })
 ```
 
-If the module export name differs from the component function name, include `#ExportName` in the
-entry ID or return the exact export name from `resolveClientEntry`. A render helper that only
-supports source-owned entries can also fail fast when `entryId` is not a `file://` URL.
+If the module export name differs from the component function name, include `#ExportName` in the entry ID or return the exact export name from `resolveClientEntry`. A render helper that only supports source-owned entries can also fail fast when `entryId` is not a `file://` URL.
 
-On the server, `clientEntry` components render like any other component. The server wraps their
-output in comment markers and serializes props into a `<script type="application/json">` tag.
+On the server, `clientEntry` components render like any other component. The server wraps their output in comment markers and serializes props into a `<script type="application/json">` tag.
 
-Client entry props must be serializable: strings, numbers, booleans, `null`, `undefined`, plain
-objects/arrays of the above, JSX elements, and `<Frame>` elements. Functions and class instances
-cannot be passed.
+Client entry props must be serializable: strings, numbers, booleans, `null`, `undefined`, plain objects/arrays of the above, JSX elements, and `<Frame>` elements. Functions and class instances cannot be passed.
 
 ## Booting the Client
 
-Use `run` to start the client runtime. It scans the document for client entry markers, loads
-modules, and hydrates each one:
+Use `run` to start the client runtime. It scans the document for client entry markers, loads modules, and hydrates each one:
 
 ```tsx
 import { run } from 'remix/ui'
@@ -137,10 +118,8 @@ await app.ready()
 
 ### `run` options
 
-- **`loadModule(moduleUrl, exportName)`** (required) — return the component function for each
-  client entry. Typically uses dynamic `import()`.
-- **`resolveFrame(src, signal, target)`** (optional) — called when a `<Frame>` loads or reloads
-  content. `target` is available when frame targeting matters.
+- **`loadModule(moduleUrl, exportName)`** (required) — return the component function for each client entry. Typically uses dynamic `import()`.
+- **`resolveFrame(src, signal, target)`** (optional) — called when a `<Frame>` loads or reloads content. `target` is available when frame targeting matters.
 
 ### `app` methods
 
@@ -152,8 +131,7 @@ await app.ready()
 
 ## Frames
 
-A `<Frame>` renders server content into the page. Frames stream after the initial HTML, nest inside
-other frames, contain client entries, and can be reloaded without full page navigation.
+A `<Frame>` renders server content into the page. Frames stream after the initial HTML, nest inside other frames, contain client entries, and can be reloaded without full page navigation.
 
 ```tsx
 import { Frame } from 'remix/ui'
@@ -177,10 +155,8 @@ function App() {
 
 ### Blocking vs non-blocking
 
-- **Without `fallback`** (blocking) — the server waits for frame content before sending the initial
-  HTML chunk
-- **With `fallback`** (non-blocking) — the fallback renders immediately; real content streams in
-  later and replaces it
+- **Without `fallback`** (blocking) — the server waits for frame content before sending the initial HTML chunk
+- **With `fallback`** (non-blocking) — the fallback renders immediately; real content streams in later and replaces it
 
 ### Reloading frames
 
@@ -197,21 +173,17 @@ await handle.frames.get('cart-summary')?.reload()
 handle.frames.top.reload()
 ```
 
-When a frame reloads, matching DOM nodes are updated in place. Client entries receive updated props
-while preserving their local component state.
+When a frame reloads, matching DOM nodes are updated in place. Client entries receive updated props while preserving their local component state.
 
 ### Nested frames
 
-Frames can nest. Each frame owns its own DOM region and hydrates client entries independently.
-During SSR, `handle.frame.src` points at the frame being rendered, while
-`handle.frames.top.src` stays fixed at the outer document URL.
+Frames can nest. Each frame owns its own DOM region and hydrates client entries independently. During SSR, `handle.frame.src` points at the frame being rendered, while `handle.frames.top.src` stays fixed at the outer document URL.
 
 ## Server Rendering
 
 ### `renderToStream`
 
-Renders a component tree to a `ReadableStream<Uint8Array>`. Sends initial HTML immediately and
-streams frame content as it resolves:
+Renders a component tree to a `ReadableStream<Uint8Array>`. Sends initial HTML immediately and streams frame content as it resolves:
 
 ```tsx
 import { renderToStream } from 'remix/ui/server'
@@ -235,11 +207,8 @@ return new Response(stream, {
 Options:
 
 - **`frameSrc`** — seeds SSR frame state; populates `handle.frame.src` and `handle.frames.top.src`
-- **`topFrameSrc`** — overrides the root frame URL for nested frame renders (carry forward from
-  `resolveFrame` context)
-- **`resolveFrame(src, target, context)`** — return HTML string, `ReadableStream<Uint8Array>`, or a
-  promise of either. `context.currentFrameSrc` is the containing frame URL; `context.topFrameSrc`
-  is the outer document URL
+- **`topFrameSrc`** — overrides the root frame URL for nested frame renders (carry forward from `resolveFrame` context)
+- **`resolveFrame(src, target, context)`** — return HTML string, `ReadableStream<Uint8Array>`, or a promise of either. `context.currentFrameSrc` is the containing frame URL; `context.topFrameSrc` is the outer document URL
 - **`onError(error)`** — called on rendering errors
 
 ### `renderToString`
@@ -253,8 +222,7 @@ let html = await renderToString(<App />)
 
 ### CSS in SSR
 
-Components using the `css` mixin have styles collected during rendering and emitted as a single
-`<style>` tag in `<head>`. No client-side style injection needed.
+Components using the `css` mixin have styles collected during rendering and emitted as a single `<style>` tag in `<head>`. No client-side style injection needed.
 
 ## Navigation
 
@@ -293,5 +261,4 @@ function App() {
 }
 ```
 
-Put `title`, `meta`, `link`, and `style` tags inside an explicit `<head>`. Bare head-like tags
-rendered outside `<head>` stay where they are — they are not moved into the document head for you.
+Put `title`, `meta`, `link`, and `style` tags inside an explicit `<head>`. Bare head-like tags rendered outside `<head>` stay where they are — they are not moved into the document head for you.

--- a/.agents/skills/remix/references/middleware-and-server.md
+++ b/.agents/skills/remix/references/middleware-and-server.md
@@ -2,22 +2,18 @@
 
 ## What This Covers
 
-How to compose the request lifecycle and bridge the router to a runtime. Read this when the task
-involves:
+How to compose the request lifecycle and bridge the router to a runtime. Read this when the task involves:
 
-- Choosing or ordering built-in middleware in the root stack
+- Choosing or ordering built-in middleware in the stack
 - Writing custom middleware that sets typed context values
-- Adding fast-exit handling (static files, CORS preflights) versus request-enriching layers
-  (sessions, auth, data loading)
+- Adding fast-exit handling (static files, CORS preflights) versus request-enriching layers (sessions, auth, data loading)
 - Choosing when to keep the generated Node server versus switching server adapters
 
-For data and persistence specifics, see `data-and-validation.md`. For session and auth specifics,
-see `auth-and-sessions.md`.
+For data and persistence specifics, see `data-and-validation.md`. For session and auth specifics, see `auth-and-sessions.md`.
 
 ## Middleware Stack
 
-Middleware runs in order for every request. Place fast-exit middleware (static files) early and
-request-enriching middleware (session, auth) later.
+Middleware runs in order for every request. Place fast-exit middleware (static files) early and request-enriching middleware (session, auth) later.
 
 Recommended ordering:
 
@@ -54,7 +50,7 @@ let router = createRouter({ middleware })
 | Middleware                 | Import                             | Use when                                                                      | Notes                                                          |
 | -------------------------- | ---------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | `staticFiles(dir, opts?)`  | `remix/middleware/static`          | Serve files from `public/` or another directory exactly as they exist on disk | Fast exit; usually near the top                                |
-| `compression()`            | `remix/middleware/compression`     | Compress text-like responses                                                  | Usually global                                                 |
+| `compression()`            | `remix/middleware/compression`     | Compress text-like responses                                                  | Usually app-wide                                               |
 | `logger()`                 | `remix/middleware/logger`          | Log requests and responses                                                    | Often development-only; `colors` can force color output on/off |
 | `cors(opts?)`              | `remix/middleware/cors`            | Endpoints must serve cross-origin browsers or preflight `OPTIONS` requests    | Usually early so preflights can short-circuit                  |
 | `cop(opts?)`               | `remix/middleware/cop`             | Reject unsafe cross-origin browser requests without synchronizer tokens       | Put before session or CSRF when used                           |
@@ -64,33 +60,26 @@ let router = createRouter({ middleware })
 | `csrf(opts?)`              | `remix/middleware/csrf`            | Session-backed form workflows need synchronizer-token CSRF protection         | Requires `session()` before it                                 |
 | `asyncContext()`           | `remix/middleware/async-context`   | Helpers outside handlers need request context via `getContext()`              | Add before helpers rely on it                                  |
 | `auth({ schemes })`        | `remix/middleware/auth`            | Resolve auth state into `context.get(Auth)`                                   | Run after `session()` for session-backed auth                  |
-| `requireAuth()`            | `remix/middleware/auth`            | A controller or action must reject anonymous access                           | Usually controller-level or action-level, not global           |
+| `requireAuth()`            | `remix/middleware/auth`            | A controller or action must reject anonymous access                           | Usually controller middleware or action middleware             |
 
 ### Static files vs browser modules
 
-- Use `staticFiles()` for files that should be served directly from disk, such as images, fonts,
-  or already-built assets in `public/`
-- Use `remix/assets` when browser modules should be compiled and served from source files with
-  import rewriting, preloads, or fingerprinted URLs
+- Use `staticFiles()` for files that should be served directly from disk, such as images, fonts, or already-built assets in `public/`
+- Use `remix/assets` when browser modules should be compiled and served from source files with import rewriting, preloads, or fingerprinted URLs
 
 ### Ordering notes
 
 - Put fast exits early: `staticFiles()`, `cors()` preflight handling, and `cop()` when used
-- Parse request bodies before middleware that depends on them, such as `methodOverride()` and form
-  field token extraction in `csrf()`
+- Parse request bodies before middleware that depends on them, such as `methodOverride()` and form field token extraction in `csrf()`
 - Run `session()` before `csrf()` and before session-backed `auth()`
 - Add `asyncContext()` before helpers or shared code call `getContext()`
-- Keep route protection like `requireAuth()` at controller or action scope unless the entire app is
-  private
+- Keep route protection like `requireAuth()` as controller middleware or action middleware unless the entire app is private
 
 ### Common stacks
 
-- **Session-backed HTML app** -> `compression()`, `staticFiles()`, optional `cop()`, `formData()`,
-  `methodOverride()`, `session()`, optional `csrf()`, `asyncContext()`, `auth({ schemes })`
-- **Cross-origin API** -> `compression()`, `cors()`, optional `asyncContext()`, optional
-  `auth({ schemes })`
-- **Upload flow** -> `compression()`, `staticFiles()`, `formData({ uploadHandler })`, then
-  sessions, auth, and data-loading middleware as needed
+- **Session-backed HTML app** -> `compression()`, `staticFiles()`, optional `cop()`, `formData()`, `methodOverride()`, `session()`, optional `csrf()`, `asyncContext()`, `auth({ schemes })`
+- **Cross-origin API** -> `compression()`, `cors()`, optional `asyncContext()`, optional `auth({ schemes })`
+- **Upload flow** -> `compression()`, `staticFiles()`, `formData({ uploadHandler })`, then sessions, auth, and data-loading middleware as needed
 
 ### Middleware with options
 
@@ -115,14 +104,11 @@ formData({
 })
 ```
 
-Errors thrown or rejected by `uploadHandler` propagate directly. Catch domain-specific upload
-errors at the route boundary when they should become user-facing `Response` objects.
+Errors thrown or rejected by `uploadHandler` propagate directly. Catch domain-specific upload errors at the route boundary when they should become user-facing `Response` objects.
 
 ## Writing Custom Middleware
 
-Middleware is a function that receives `(context, next)`. Return a `Response` to short-circuit, call
-and return `next()` when you need the downstream response, or return nothing when you only set
-context and want the router to continue automatically.
+Middleware is a function that receives `(context, next)`. Return a `Response` to short-circuit, or call and return `next()` to continue the chain. As of `remix@3.0.0-beta.4`, middleware that returns `undefined` without calling `next()` throws at runtime — every code path must either return a `Response` or `return next()` explicitly. Even "I just set context, then continue" looks like `context.set(Key, value); return next()`.
 
 ### Setting context values
 
@@ -158,9 +144,7 @@ export function requireAdmin(): Middleware {
 
 ### Async context for helpers
 
-`asyncContext()` stores the request context in `AsyncLocalStorage` so helpers can reach it
-without the context being threaded through every call. Wrap `getContext()` in app-specific
-helpers:
+`asyncContext()` stores the request context in `AsyncLocalStorage` so helpers can reach it without the context being threaded through every call. Wrap `getContext()` in app-specific helpers:
 
 ```typescript
 // app/utils/context.ts
@@ -191,17 +175,17 @@ export function getCurrentUserSafely() {
 }
 ```
 
-## Middleware Layers
+## Middleware Types
 
-Middleware can be applied at three levels:
+Middleware has three API-owned forms:
 
-1. **Router-level** — runs for every request:
+1. **Router middleware** — runs for every request:
 
    ```typescript
-   let router = createRouter({ middleware: [...] })
+   let router = createRouter({ middleware: [logger(), session(cookie, storage)] })
    ```
 
-2. **Controller-level** — runs for the direct actions in one controller:
+2. **Controller middleware** — runs for the direct actions in one controller:
 
    ```typescript
    export default createController(routes.account, {
@@ -210,23 +194,23 @@ Middleware can be applied at three levels:
    })
    ```
 
-   Controller middleware does not flow into other controllers. Add the middleware to each
-   controller that needs it.
+   Controller middleware does not flow into other controllers. Add the middleware to each controller that needs it.
 
-3. **Action-level** — runs for a single route:
+3. **Action middleware** — runs for a single action:
+
    ```typescript
    router.get(routes.account.index, {
      middleware: [requireAuth()],
-     handler: accountAction.handler,
+     handler(context) {
+       return render(<AccountPage identity={context.auth.identity} />)
+     },
    })
    ```
 
+Prefer inline arrays for `middleware` options. Use `RouterContext<typeof router>` to derive an app context from a router that uses inline middleware. Use `createMiddleware()` only when a chain is stored in a variable and its exact tuple type needs to be preserved, such as when deriving `MiddlewareContext<typeof rootMiddleware>` without a router value, exporting a reusable chain, or returning a chain from a factory.
+
 ## Node Server Setup
 
-New apps already include a `server.ts` that adapts the app router with
-`remix/node-fetch-server`. Keep that generated server unless the task specifically needs to change
-runtime behavior such as host/protocol handling, TLS, HTTP/2, WebSockets, deployment lifecycle, or
-test-only server setup.
+New apps already include a `server.ts` that adapts the app router with `remix/node-fetch-server`. Keep that generated server unless the task specifically needs to change runtime behavior such as host/protocol handling, TLS, HTTP/2, WebSockets, deployment lifecycle, or test-only server setup.
 
-Use `remix/node-fetch-server` when you want to keep owning a standard Node `http`, `https`, or
-`http2` server directly.
+Use `remix/node-fetch-server` when you want to keep owning a standard Node `http`, `https`, or `http2` server directly.

--- a/.agents/skills/remix/references/mixins-styling-events.md
+++ b/.agents/skills/remix/references/mixins-styling-events.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-How to attach behavior, styles, and DOM-aware setup to host elements with `mix`. Read this when the
-task involves:
+How to attach behavior, styles, and DOM-aware setup to host elements with `mix`. Read this when the task involves:
 
 - DOM event handling with `on(...)`
 - Static styling with `css(...)` and dynamic styling with `style`
@@ -12,18 +11,13 @@ task involves:
 - Native click, pointer, and keyboard behavior with `on(...)`, plus attributes with `attrs(...)`
 - Element-level animation mixins from `remix/ui/animation`
 
-For richer animation work (springs, tweens, layout transitions), see `animate-elements.md`. For
-authoring custom mixins, see `create-mixins.md`. For component lifecycle and updates, see
-`component-model.md`.
+For richer animation work (springs, tweens, layout transitions), see `animate-elements.md`. For authoring custom mixins, see `create-mixins.md`. For component lifecycle and updates, see `component-model.md`.
 
-Compose behavior on host elements with `mix`. Pass a single mixin directly (`mix={on(...)}`), or
-an array when composing multiple mixins (`mix={[css(...), on(...)]}`). Core mixins are imported
-from `remix/ui`; animation mixins are imported from `remix/ui/animation`.
+Compose behavior on host elements with `mix`. Pass a single mixin directly (`mix={on(...)}`), or an array when composing multiple mixins (`mix={[css(...), on(...)]}`). Core mixins are imported from `remix/ui`; animation mixins are imported from `remix/ui/animation`.
 
 ## `on(type, handler, capture?)`
 
-Attaches a typed DOM event handler. The handler receives the event and an `AbortSignal` that aborts
-when the handler is re-entered or the component is removed — this prevents race conditions:
+Attaches a typed DOM event handler. The handler receives the event and an `AbortSignal` that aborts when the handler is re-entered or the component is removed — this prevents race conditions:
 
 ```tsx
 <input
@@ -56,9 +50,7 @@ Multiple events on the same element:
 
 ## `css(styles)`
 
-Applies generated class names for CSS object styles. Produces static CSS rules inserted into the
-document. Supports pseudo-selectors, pseudo-elements, attribute selectors, descendant selectors, and
-media queries using `&` to reference the current element:
+Applies generated class names for CSS object styles. Produces static CSS rules inserted into the document. Supports pseudo-selectors, pseudo-elements, attribute selectors, descendant selectors, and media queries using `&` to reference the current element:
 
 ```tsx
 <button
@@ -80,9 +72,7 @@ media queries using `&` to reference the current element:
 
 ### `css(...)` vs `style` prop
 
-Use `css(...)` for static styles, selectors, and media queries. Use `style` for dynamic values that
-change often. Prefer CSS nested selectors for parent-state-affects-children over managing hover/focus
-state in JavaScript:
+Use `css(...)` for static styles, selectors, and media queries. Use `style` for dynamic values that change often. Prefer CSS nested selectors for parent-state-affects-children over managing hover/focus state in JavaScript:
 
 ```tsx
 <div
@@ -96,8 +86,7 @@ state in JavaScript:
 
 ## `ref(callback)`
 
-Calls a callback when an element is inserted. The callback receives the DOM node and an
-`AbortSignal` that aborts when the element is removed:
+Calls a callback when an element is inserted. The callback receives the DOM node and an `AbortSignal` that aborts when the element is removed:
 
 ```tsx
 <input mix={ref((node) => node.focus())} />
@@ -116,8 +105,7 @@ The `ref` callback runs once when the element is first rendered, not on every up
 
 ## `link(href, options?)`
 
-Adds client-side navigation behavior to any element. Makes non-anchor elements behave like Remix
-navigation links:
+Adds client-side navigation behavior to any element. Makes non-anchor elements behave like Remix navigation links:
 
 ```tsx
 <article mix={link('/courses/intro')}>
@@ -125,20 +113,17 @@ navigation links:
 </article>
 ```
 
-Options match `NavigationOptions`: `src`, `target`, `history` (`'push' | 'replace'`),
-`resetScroll`.
+Options match `NavigationOptions`: `src`, `target`, `history` (`'push' | 'replace'`), `resetScroll`.
 
 ## Native press and keyboard interactions
 
-Use native DOM events directly with `on(...)`. For buttons and links, `click` already includes
-keyboard activation when the element has the right semantics:
+Use native DOM events directly with `on(...)`. For buttons and links, `click` already includes keyboard activation when the element has the right semantics:
 
 ```tsx
 <button mix={on('click', () => doAction())}>Action</button>
 ```
 
-For gesture-specific behavior, compose the pointer or keyboard events the interaction actually
-needs:
+For gesture-specific behavior, compose the pointer or keyboard events the interaction actually needs:
 
 ```tsx
 <button
@@ -177,8 +162,7 @@ Animates an element when it is inserted into the DOM. Config specifies the **sta
 
 ### `animateExit(config)`
 
-Animates an element when it is removed. Config specifies the **ending** style. The element is kept
-in the DOM until the animation completes:
+Animates an element when it is removed. Config specifies the **ending** style. The element is kept in the DOM until the animation completes:
 
 ```tsx
 {
@@ -206,8 +190,6 @@ Animates layout changes (position/size) using FLIP-style transforms:
 }
 ```
 
-Options: `duration` (default 200ms), `easing` (default spring snappy), `size` (boolean, default
-true — include scale projection for size changes).
+Options: `duration` (default 200ms), `easing` (default spring snappy), `size` (boolean, default true — include scale projection for size changes).
 
-Always key elements you expect to animate. Use `...spring(preset)` to spread `duration` and
-`easing` into any animation config.
+Always key elements you expect to animate. Use `...spring(preset)` to spread `duration` and `easing` into any animation config.

--- a/.agents/skills/remix/references/routing-and-controllers.md
+++ b/.agents/skills/remix/references/routing-and-controllers.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-Patterns for declaring URLs, handling requests, and wiring routes to controllers. Read this when
-the task involves:
+Patterns for declaring URLs, handling requests, and wiring routes to controllers. Read this when the task involves:
 
 - Defining or changing the URL surface of the app
 - Writing or reorganizing controllers and actions
@@ -11,9 +10,7 @@ the task involves:
 - Returning a `Response` for HTML, redirects, JSON, or errors
 - Generating internal URLs with `.href()`
 
-The companion reference for shaping `Request` bodies, validating input, and dealing with persisted
-data is `data-and-validation.md`. For request lifecycle and middleware ordering, see
-`middleware-and-server.md`.
+The companion reference for shaping `Request` bodies, validating input, and dealing with persisted data is `data-and-validation.md`. For request lifecycle and middleware ordering, see `middleware-and-server.md`.
 
 ## Route Builders
 
@@ -21,10 +18,7 @@ Import all route builders from `remix/routes`.
 
 ### `route(prefix, map)` — nested route group
 
-Adds a URL prefix to all children. Can also be called as `route(map)` without a prefix for a
-top-level grouping. Inside `route(...)`, a nested map may be either a `route('prefix', { ... })`
-call (when you want a shared URL prefix) or a plain object literal (when each leaf already owns
-its absolute path).
+Adds a URL prefix to all children. Can also be called as `route(map)` without a prefix for a top-level grouping. Inside `route(...)`, a nested map may be either a `route('prefix', { ... })` call (when you want a shared URL prefix) or a plain object literal (when each leaf already owns its absolute path).
 
 ```typescript
 import { route, get, post } from 'remix/routes'
@@ -58,8 +52,7 @@ export const routes = route({
 
 ### `form(path, options?)` — form route
 
-Creates a GET + POST pair for HTML form workflows. Expands to an `index` (GET) and an `action`
-(POST) by default.
+Creates a GET + POST pair for HTML form workflows. Expands to an `index` (GET) and an `action` (POST) by default.
 
 ```typescript
 contact: form('contact')
@@ -92,9 +85,7 @@ redirect(routes.account.orders.show.href({ orderId: '42' }))
 
 ## Actions
 
-An action is the handler for one leaf route. In Remix app code, actions should live in controllers.
-Use `Action` only when a reusable helper needs to type one action before it is added to a
-controller or when you are doing low-level router wiring outside the `app/actions` convention:
+An action is the handler for one leaf route. In Remix app code, actions should live in controllers. Use `Action` only when a reusable helper needs to type one action before it is added to a controller or when you are doing low-level router wiring outside the `app/actions` convention:
 
 ```typescript
 import { createAction } from 'remix/router'
@@ -117,21 +108,23 @@ The handler receives a context object with:
 - `url` — the request URL
 - `request` — the raw `Request`
 
-Actions with inline middleware:
+Actions with action middleware:
 
 ```typescript
+import { createAction } from 'remix/router'
 import { requireAuth } from 'remix/middleware/auth'
 
-router.get(routes.account.index, {
+export const account = createAction(routes.account.index, {
   middleware: [requireAuth()],
-  handler: accountAction.handler,
+  handler(context) {
+    return render(<AccountPage />)
+  },
 })
 ```
 
 ## Returning Responses
 
-An action returns a `Response`. The shape of that response is part of the route contract, and
-choosing it well saves a lot of glue elsewhere.
+An action returns a `Response`. The shape of that response is part of the route contract, and choosing it well saves a lot of glue elsewhere.
 
 ### Render HTML
 
@@ -147,8 +140,7 @@ async handler({ get }) {
 
 ### Redirect after a mutation
 
-For state-changing routes (POST, PUT, PATCH, DELETE), the canonical reply is a redirect to the
-resulting page. Pass `303` explicitly when you want a POST-redirect-GET flow:
+For state-changing routes (POST, PUT, PATCH, DELETE), the canonical reply is a redirect to the resulting page. Pass `303` explicitly when you want a POST-redirect-GET flow:
 
 ```typescript
 import { redirect } from 'remix/response/redirect'
@@ -167,13 +159,11 @@ async create({ get }) {
 }
 ```
 
-This pattern works without JavaScript and stays compatible with `clientEntry(...)` enhancements
-on top.
+This pattern works without JavaScript and stays compatible with `clientEntry(...)` enhancements on top.
 
 ### Return an error response
 
-For expected failures — validation, conflict, not found — return a `Response` directly. Reserve
-thrown errors for genuinely unexpected failures.
+For expected failures — validation, conflict, not found — return a `Response` directly. Reserve thrown errors for genuinely unexpected failures.
 
 ```typescript
 async show({ get, params }) {
@@ -198,9 +188,7 @@ if (!parsed.success) {
 
 ### Return JSON
 
-For routes consumed by client code rather than rendered as a page (autocomplete endpoints, polling
-APIs, inter-service calls), return a JSON `Response`. Use `SuperHeaders` from `remix/headers` when
-typed header accessors make the response clearer:
+For routes consumed by client code rather than rendered as a page (autocomplete endpoints, polling APIs, inter-service calls), return a JSON `Response`. Use `SuperHeaders` from `remix/headers` when typed header accessors make the response clearer:
 
 ```typescript
 import Headers from 'remix/headers'
@@ -214,20 +202,13 @@ return new Response(JSON.stringify({ results }), {
 })
 ```
 
-If you find yourself returning JSON for what is really a browser form submission, prefer the
-redirect-after-POST pattern instead. JSON-only mutation endpoints make it harder to support
-non-JS clients, harder to share rendering logic, and easier for the client to drift out of sync
-with the server.
+If you find yourself returning JSON for what is really a browser form submission, prefer the redirect-after-POST pattern instead. JSON-only mutation endpoints make it harder to support non-JS clients, harder to share rendering logic, and easier for the client to drift out of sync with the server.
 
 ## Controllers
 
-A controller owns the direct leaf routes in one route map. Each key in `actions` matches a direct
-leaf route key in the route definition passed to `router.map(...)`. Nested route-map keys do not
-belong inside a controller's `actions`; map those route maps with their own controllers.
+A controller owns the direct leaf routes in one route map. Each key in `actions` matches a direct leaf route key in the route definition passed to `router.map(...)`. Nested route-map keys do not belong inside a controller's `actions`; map those route maps with their own controllers.
 
-Configure `RouterTypes.context` with your app context in the router module, then use
-`createController()` so `get(Database)`, `get(Session)`, `get(Auth)`, etc. are typed against your
-middleware stack without repeating a type clause on every controller.
+Configure `RouterTypes.context` with your app context in the router module, then use `createController()` so `get(Database)`, `get(Session)`, `get(Auth)`, etc. are typed against your middleware stack without repeating a type clause on every controller.
 
 ```typescript
 import { createController } from 'remix/router'
@@ -284,8 +265,7 @@ Because `account` is a nested route map, it is not an action key in the root con
 
 ### Nested route maps
 
-Nested route maps use their own controllers under `app/actions/<route-key>/controller.tsx`.
-Directory names under `app/actions/` are route-map keys, not URL path segments.
+Nested route maps use their own controllers under `app/actions/<route-key>/controller.tsx`. Directory names under `app/actions/` are route-map keys, not URL path segments.
 
 ```typescript
 // app/actions/account/controller.tsx
@@ -328,8 +308,7 @@ router.map(routes.account.settings, accountSettingsController)
 
 ### Controller middleware
 
-The `middleware` array on a controller runs only for the direct actions in that controller, before
-action-level middleware. It does not apply to other controllers.
+The `middleware` array on a controller runs only for the direct actions in that controller, before action middleware. It does not apply to other controllers.
 
 ```typescript
 export default createController(routes.admin, {
@@ -342,8 +321,7 @@ export default createController(routes.admin, {
 
 ## Registering Routes
 
-Use `router.map` for route maps and controllers. Map each nested route map explicitly. Use verb
-methods only for low-level router wiring outside the `app/actions` controller convention.
+Use `router.map` for route maps and controllers. Map each nested route map explicitly. Use verb methods only for low-level router wiring outside the `app/actions` controller convention.
 
 ```typescript
 let router = createRouter({ middleware })
@@ -363,23 +341,16 @@ router.post(routes.logout, logoutAction)
 
 ## Typed Context
 
-Define an `AppContext` type from your middleware stack, then make it the default context used by
-`createAction()` and `createController()`:
+Define an `AppContext` type from your router, then make it the default context used by `createAction()` and `createController()`:
 
 ```typescript
-import type { MiddlewareContext, ContextWithParams, AnyParams } from 'remix/router'
+import { createRouter, type RouterContext } from 'remix/router'
 
-type RootMiddleware = [
-  ReturnType<typeof formData>,
-  ReturnType<typeof session>,
-  ReturnType<typeof loadDatabase>,
-  ReturnType<typeof loadAuth>,
-]
+export const router = createRouter({
+  middleware: [formData(), session(cookie, storage), loadDatabase(), loadAuth()],
+})
 
-export type AppContext<params extends AnyParams = {}> = ContextWithParams<
-  MiddlewareContext<RootMiddleware>,
-  params
->
+export type AppContext = RouterContext<typeof router>
 
 declare module 'remix/router' {
   interface RouterTypes {

--- a/.agents/skills/remix/references/testing-patterns.md
+++ b/.agents/skills/remix/references/testing-patterns.md
@@ -2,8 +2,7 @@
 
 ## What This Covers
 
-How to test the two layers most Remix code lives in: HTTP behavior and DOM behavior. Read this when
-the task involves:
+How to test the two layers most Remix code lives in: HTTP behavior and DOM behavior. Read this when the task involves:
 
 - Driving the router with `router.fetch(new Request(...))` and asserting on the returned `Response`
 - Building a fresh router per test for session, storage, or database isolation
@@ -12,24 +11,18 @@ the task involves:
 - Using adjacent CLI checks such as `remix routes`, `remix doctor`, and `remix version`
 - Choosing which layer to test for a given behavior
 
-For session and auth test setup, see `auth-and-sessions.md`. For component lifecycle, see
-`component-model.md`.
+For session and auth test setup, see `auth-and-sessions.md`. For component lifecycle, see `component-model.md`.
 
 ## Two Shapes
 
-Remix tests run with `remix test`, use `remix/test` for the test framework, and use
-`remix/assert` for assertions. Two main shapes:
+Remix tests run with `remix test`, use `remix/test` for the test framework, and use `remix/assert` for assertions. Two main shapes:
 
-- **Server / router tests** — drive the router with `router.fetch(new Request(...))` and assert
-  on the returned `Response`. No DOM, no browser harness.
-- **Component tests** — render a component into a real DOM `Element` with `render(...)`, or use
-  `createRoot(...)` directly when you need lower-level root control.
+- **Server / router tests** — drive the router with `router.fetch(new Request(...))` and assert on the returned `Response`. No DOM, no browser harness.
+- **Component tests** — render a component into a real DOM `Element` with `render(...)`, or use `createRoot(...)` directly when you need lower-level root control.
 
 ## Server / Router Tests
 
-Treat the router as a pure `(Request) => Promise<Response>` function. Build a fresh app router
-per test (or per suite) so middleware state — sessions, in-memory storage, the database — stays
-isolated.
+Treat the router as a pure `(Request) => Promise<Response>` function. Build a fresh app router per test (or per suite) so middleware state — sessions, in-memory storage, the database — stays isolated.
 
 ```ts
 import * as assert from 'remix/assert'
@@ -49,10 +42,7 @@ describe('home', () => {
 })
 ```
 
-Use `routes.<name>.href(...)` to build URLs in tests so they stay in sync with the route
-definition. For form-style POSTs, attach a `FormData` body to the `Request`. For tests that need
-a known session, swap in `createMemorySessionStorage()` and a test cookie when constructing the
-router.
+Use `routes.<name>.href(...)` to build URLs in tests so they stay in sync with the route definition. For form-style POSTs, attach a `FormData` body to the `Request`. For tests that need a known session, swap in `createMemorySessionStorage()` and a test cookie when constructing the router.
 
 ```ts
 import { createMemorySessionStorage } from 'remix/session-storage/memory'
@@ -64,8 +54,7 @@ let router = createBookstoreRouter({
 })
 ```
 
-Use `createTestServer` from `remix/node-fetch-server/test` when the behavior depends on a real
-HTTP origin, redirects, streaming, cookies through a network boundary, or browser-style `fetch`:
+Use `createTestServer` from `remix/node-fetch-server/test` when the behavior depends on a real HTTP origin, redirects, streaming, cookies through a network boundary, or browser-style `fetch`:
 
 ```ts
 import { createTestServer } from 'remix/node-fetch-server/test'
@@ -102,16 +91,11 @@ export default {
 }
 ```
 
-Use `remix test --coverage` to enable coverage with defaults. Use `glob.exclude` when discovery
-would otherwise enter generated output, symlinked workspaces, or other paths that should not
-produce tests.
+Use `remix test --coverage` to enable coverage with defaults. Use `glob.exclude` when discovery would otherwise enter generated output, symlinked workspaces, or other paths that should not produce tests.
 
 ## Component Tests
 
-Use `render(...)` from `remix/ui/test` for most component tests. It creates a real DOM container,
-flushes the initial render, and returns `act(...)` so interactions can flush pending updates before
-assertions. Use `createRoot(container)` from `remix/ui` directly when a test needs explicit control
-over root rendering, flushing, or disposal.
+Use `render(...)` from `remix/ui/test` for most component tests. It creates a real DOM container, flushes the initial render, and returns `act(...)` so interactions can flush pending updates before assertions. Use `createRoot(container)` from `remix/ui` directly when a test needs explicit control over root rendering, flushing, or disposal.
 
 ### Basic pattern
 
@@ -130,8 +114,7 @@ result.cleanup()
 
 ### Why act / flush
 
-- **After initial render** — ensures event listeners are attached and the DOM is ready for
-  interaction.
+- **After initial render** — ensures event listeners are attached and the DOM is ready for interaction.
 - **After interactions** — applies updates from `handle.update()` calls triggered by events.
 - **After async work resolves** — applies updates from resolved `queueTask(...)` callbacks.
 
@@ -152,8 +135,7 @@ assert.equal(result.container.textContent, 'Expected data')
 
 ### Component removal
 
-Use `result.cleanup()` or `root.dispose()` to remove the component tree and verify cleanup
-behavior:
+Use `result.cleanup()` or `root.dispose()` to remove the component tree and verify cleanup behavior:
 
 ```tsx
 let result = render(<MyComponent />)
@@ -168,5 +150,4 @@ assert.throws(() => result.$('.content'), /cleaned up/)
 
 - Prefer real DOM interactions over mocking framework behavior.
 - Avoid testing implementation-only markers unless they are the only stable synchronization point.
-- One representative flow proving a behavior is better than repeating the same assertion across many
-  paths.
+- One representative flow proving a behavior is better than repeating the same assertion across many paths.

--- a/app/actions/admin/admin-stickers-page.tsx
+++ b/app/actions/admin/admin-stickers-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../../routes.ts'
 import { Document } from '../../ui/document.tsx'
@@ -15,18 +15,17 @@ export interface AdminStickerRow {
   createdRelative: string
 }
 
-export function AdminStickersPage() {
-  return ({
-    user,
-    stickers,
-    page,
-    hasNext,
-  }: {
-    user: HeaderUser
-    stickers: AdminStickerRow[]
-    page: number
-    hasNext: boolean
-  }) => (
+interface AdminStickersPageProps {
+  user: HeaderUser
+  stickers: AdminStickerRow[]
+  page: number
+  hasNext: boolean
+}
+
+export function AdminStickersPage(handle: Handle<AdminStickersPageProps>) {
+  return () => {
+    const { user, stickers, page, hasNext } = handle.props
+    return (
     <Document title="stickertrade - admin / stickers" user={user}>
       <main>
         <div mix={headerStyle}>
@@ -99,7 +98,8 @@ export function AdminStickersPage() {
         </table>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const headerStyle = css({

--- a/app/actions/admin/admin-surfaces-page.tsx
+++ b/app/actions/admin/admin-surfaces-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../../routes.ts'
 import { Document } from '../../ui/document.tsx'
@@ -15,18 +15,17 @@ export interface AdminSurfaceRow {
   createdRelative: string
 }
 
-export function AdminSurfacesPage() {
-  return ({
-    user,
-    surfaces,
-    page,
-    hasNext,
-  }: {
-    user: HeaderUser
-    surfaces: AdminSurfaceRow[]
-    page: number
-    hasNext: boolean
-  }) => (
+interface AdminSurfacesPageProps {
+  user: HeaderUser
+  surfaces: AdminSurfaceRow[]
+  page: number
+  hasNext: boolean
+}
+
+export function AdminSurfacesPage(handle: Handle<AdminSurfacesPageProps>) {
+  return () => {
+    const { user, surfaces, page, hasNext } = handle.props
+    return (
     <Document title="stickertrade - admin / surfaces" user={user}>
       <main>
         <div mix={headerStyle}>
@@ -99,7 +98,8 @@ export function AdminSurfacesPage() {
         </table>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const headerStyle = css({

--- a/app/actions/admin/admin-users-page.tsx
+++ b/app/actions/admin/admin-users-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../../routes.ts'
 import { Document } from '../../ui/document.tsx'
@@ -15,18 +15,17 @@ export interface AdminUserRow {
   updatedRelative: string
 }
 
-export function AdminUsersPage() {
-  return ({
-    user,
-    users,
-    page,
-    hasNext,
-  }: {
-    user: HeaderUser
-    users: AdminUserRow[]
-    page: number
-    hasNext: boolean
-  }) => (
+interface AdminUsersPageProps {
+  user: HeaderUser
+  users: AdminUserRow[]
+  page: number
+  hasNext: boolean
+}
+
+export function AdminUsersPage(handle: Handle<AdminUsersPageProps>) {
+  return () => {
+    const { user, users, page, hasNext } = handle.props
+    return (
     <Document title="stickertrade - admin / users" user={user}>
       <main>
         <div mix={headerStyle}>
@@ -84,7 +83,8 @@ export function AdminUsersPage() {
         </table>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const headerStyle = css({

--- a/app/actions/batch-upload-stickers-page.tsx
+++ b/app/actions/batch-upload-stickers-page.tsx
@@ -1,6 +1,6 @@
 import { getContext } from 'remix/middleware/async-context'
 import { getCsrfToken } from 'remix/middleware/csrf'
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { BatchUploadStickersApp } from '../assets/batch-upload-stickers/controller.tsx'
 import { routes } from '../routes.ts'
@@ -20,8 +20,9 @@ export interface BatchUploadStickersPageProps {
 const TRANSFORMERS_VERSION = '4.2.0'
 const TRANSFORMERS_CDN = `https://cdn.jsdelivr.net/npm/@huggingface/transformers@${TRANSFORMERS_VERSION}/+esm`
 
-export function BatchUploadStickersPage() {
-  return ({ user }: BatchUploadStickersPageProps) => {
+export function BatchUploadStickersPage(handle: Handle<BatchUploadStickersPageProps>) {
+  return () => {
+    const { user } = handle.props
     // Self-resolve the CSRF token here (same pattern as `CsrfField`); the
     // client bundle reads it back from the `<meta>` tag to POST to
     // `/upload-sticker` from JS without a server-rendered form.

--- a/app/actions/brand-page.tsx
+++ b/app/actions/brand-page.tsx
@@ -1,11 +1,17 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { Document } from '../ui/document.tsx'
 import { colors } from '../ui/theme.ts'
 import type { HeaderUser } from '../ui/header.tsx'
 
-export function BrandPage() {
-  return ({ user }: { user: HeaderUser | null }) => (
+interface BrandPageProps {
+  user: HeaderUser | null
+}
+
+export function BrandPage(handle: Handle<BrandPageProps>) {
+  return () => {
+    const { user } = handle.props
+    return (
     <Document title="stickertrade - brand" user={user}>
       <main mix={css({ maxWidth: '42rem', margin: '0 auto' })}>
         <h1 mix={h1}>brand</h1>
@@ -46,7 +52,8 @@ export function BrandPage() {
         </div>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const h1 = css({ fontSize: '1.5rem', marginBottom: '0.5rem' })

--- a/app/actions/dev-log-page.tsx
+++ b/app/actions/dev-log-page.tsx
@@ -1,18 +1,19 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { colors } from '../ui/theme.ts'
 
-export function DevLogPage() {
-  return ({
-    user,
-    log,
-  }: {
-    user: HeaderUser | null
-    log: { slug: string; title: string; dateString: string; html: string }
-  }) => (
+interface DevLogPageProps {
+  user: HeaderUser | null
+  log: { slug: string; title: string; dateString: string; html: string }
+}
+
+export function DevLogPage(handle: Handle<DevLogPageProps>) {
+  return () => {
+    const { user, log } = handle.props
+    return (
     <Document
       title={`stickertrade - dev log | ${log.title}`}
       user={user}
@@ -31,7 +32,8 @@ export function DevLogPage() {
         <div mix={markdownStyle} innerHTML={log.html} />
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const markdownStyle = css({

--- a/app/actions/dev-logs-index-page.tsx
+++ b/app/actions/dev-logs-index-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -11,8 +11,15 @@ export interface DevLogSummary {
   dateString: string
 }
 
-export function DevLogsIndexPage() {
-  return ({ user, logs }: { user: HeaderUser | null; logs: DevLogSummary[] }) => (
+interface DevLogsIndexPageProps {
+  user: HeaderUser | null
+  logs: DevLogSummary[]
+}
+
+export function DevLogsIndexPage(handle: Handle<DevLogsIndexPageProps>) {
+  return () => {
+    const { user, logs } = handle.props
+    return (
     <Document title="stickertrade - dev logs" user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>dev logs</h1>
@@ -43,7 +50,8 @@ export function DevLogsIndexPage() {
         </ul>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const feedLinkStyle = css({

--- a/app/actions/edit-profile-page.tsx
+++ b/app/actions/edit-profile-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -37,18 +37,20 @@ export interface EditProfilePageProps {
   newToken?: { name: string; plaintext: string }
 }
 
-export function EditProfilePage() {
-  return ({
-    user,
-    avatarErrors = {},
-    avatarFlash,
-    passwordErrors = {},
-    passwordFlash,
-    tokens = [],
-    tokenErrors = {},
-    tokenFlash,
-    newToken,
-  }: EditProfilePageProps) => (
+export function EditProfilePage(handle: Handle<EditProfilePageProps>) {
+  return () => {
+    const {
+      user,
+      avatarErrors = {},
+      avatarFlash,
+      passwordErrors = {},
+      passwordFlash,
+      tokens = [],
+      tokenErrors = {},
+      tokenFlash,
+      newToken,
+    } = handle.props
+    return (
     <Document title="stickertrade - edit profile" user={user}>
       <main mix={css({ maxWidth: '28rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>edit profile</h1>
@@ -185,7 +187,8 @@ export function EditProfilePage() {
         </section>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const sectionStyle = css({

--- a/app/actions/edit-sticker-page.tsx
+++ b/app/actions/edit-sticker-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -20,8 +20,10 @@ export interface EditStickerPageProps {
   flash?: string
 }
 
-export function EditStickerPage() {
-  return ({ user, sticker, errors = {}, flash }: EditStickerPageProps) => (
+export function EditStickerPage(handle: Handle<EditStickerPageProps>) {
+  return () => {
+    const { user, sticker, errors = {}, flash } = handle.props
+    return (
     <Document title={`stickertrade - edit ${sticker.name}`} user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>edit sticker</h1>
@@ -55,7 +57,8 @@ export function EditStickerPage() {
         </form>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const previewStyle = css({

--- a/app/actions/edit-surface-page.tsx
+++ b/app/actions/edit-surface-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -33,8 +33,10 @@ export interface EditSurfacePageProps {
   flash?: string
 }
 
-export function EditSurfacePage() {
-  return ({ user, surface, images, errors = {}, flash }: EditSurfacePageProps) => (
+export function EditSurfacePage(handle: Handle<EditSurfacePageProps>) {
+  return () => {
+    const { user, surface, images, errors = {}, flash } = handle.props
+    return (
     <Document title={`stickertrade - edit ${surface.name}`} user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>edit surface</h1>
@@ -131,7 +133,8 @@ export function EditSurfacePage() {
         </section>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const textareaExtraStyle = css({

--- a/app/actions/home-page.tsx
+++ b/app/actions/home-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -15,8 +15,10 @@ export interface HomePageProps {
   surfaceOfTheDay: SurfaceCardSurface | null
 }
 
-export function HomePage() {
-  return ({ user, stickers, users, surfaceOfTheDay }: HomePageProps) => (
+export function HomePage(handle: Handle<HomePageProps>) {
+  return () => {
+    const { user, stickers, users, surfaceOfTheDay } = handle.props
+    return (
     <Document
       user={user}
       og={{
@@ -67,7 +69,8 @@ export function HomePage() {
         </div>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const sectionHeading = css({

--- a/app/actions/invitation-page.tsx
+++ b/app/actions/invitation-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -12,14 +12,16 @@ export interface InvitationPageProps {
   values?: { username?: string }
 }
 
-export function InvitationPage() {
-  return ({
-    invitationId,
-    from,
-    createdRelative,
-    errors = {},
-    values = {},
-  }: InvitationPageProps) => (
+export function InvitationPage(handle: Handle<InvitationPageProps>) {
+  return () => {
+    const {
+      invitationId,
+      from,
+      createdRelative,
+      errors = {},
+      values = {},
+    } = handle.props
+    return (
     <Document title={`stickertrade - invitation from ${from.username}`}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={titleStyle}>you have been invited to stickertrade! 🎉</h1>
@@ -55,7 +57,8 @@ export function InvitationPage() {
         </div>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const titleStyle = css({

--- a/app/actions/invitations/invitations-page.tsx
+++ b/app/actions/invitations/invitations-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { CopyButton } from '../../assets/copy-button.tsx'
 import { routes } from '../../routes.ts'
@@ -20,8 +20,9 @@ export interface InvitationsPageProps {
   invitationsEnabled: boolean
 }
 
-export function InvitationsPage() {
-  return ({ user, invitations, remaining, invitationsEnabled }: InvitationsPageProps) => {
+export function InvitationsPage(handle: Handle<InvitationsPageProps>) {
+  return () => {
+    const { user, invitations, remaining, invitationsEnabled } = handle.props
     const isAdmin = user.role === 'ADMIN'
     const blocked = !invitationsEnabled && !isAdmin
     return (

--- a/app/actions/login-page.tsx
+++ b/app/actions/login-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -10,8 +10,10 @@ export interface LoginPageProps {
   flash?: string
 }
 
-export function LoginPage() {
-  return ({ errors = {}, values = {}, flash }: LoginPageProps) => (
+export function LoginPage(handle: Handle<LoginPageProps>) {
+  return () => {
+    const { errors = {}, values = {}, flash } = handle.props
+    return (
     <Document title="stickertrade - login">
       <main mix={css({ maxWidth: '24rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>login</h1>
@@ -25,5 +27,6 @@ export function LoginPage() {
         </form>
       </main>
     </Document>
-  )
+    )
+  }
 }

--- a/app/actions/profile-page.tsx
+++ b/app/actions/profile-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -22,8 +22,9 @@ export interface ProfilePageProps {
   }
 }
 
-export function ProfilePage() {
-  return ({ user, profile }: ProfilePageProps) => {
+export function ProfilePage(handle: Handle<ProfilePageProps>) {
+  return () => {
+    const { user, profile } = handle.props
     const isOwner = user?.username === profile.username
     const stickerCount = profile.stickers.length
     return (

--- a/app/actions/roadmap-page.tsx
+++ b/app/actions/roadmap-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
@@ -12,8 +12,15 @@ export interface RoadmapTask {
   description?: string // already-rendered HTML
 }
 
-export function RoadmapPage() {
-  return ({ user, tasks }: { user: HeaderUser | null; tasks: RoadmapTask[] }) => (
+interface RoadmapPageProps {
+  user: HeaderUser | null
+  tasks: RoadmapTask[]
+}
+
+export function RoadmapPage(handle: Handle<RoadmapPageProps>) {
+  return () => {
+    const { user, tasks } = handle.props
+    return (
     <Document title="stickertrade - roadmap" user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>roadmap</h1>
@@ -37,7 +44,8 @@ export function RoadmapPage() {
         </p>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const listStyle = css({

--- a/app/actions/sticker-page.tsx
+++ b/app/actions/sticker-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -17,8 +17,9 @@ export interface StickerPageProps {
   }
 }
 
-export function StickerPage() {
-  return ({ user, sticker }: StickerPageProps) => {
+export function StickerPage(handle: Handle<StickerPageProps>) {
+  return () => {
+    const { user, sticker } = handle.props
     const canEdit =
       user != null && (user.username === sticker.owner?.username || user.role === 'ADMIN')
     const ownerLabel = sticker.owner ? `by ${sticker.owner.username}` : '(no owner)'

--- a/app/actions/stickers-page.tsx
+++ b/app/actions/stickers-page.tsx
@@ -1,11 +1,18 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { StickerCard, type StickerCardSticker } from '../ui/sticker-card.tsx'
 
-export function StickersPage() {
-  return ({ user, stickers }: { user: HeaderUser | null; stickers: StickerCardSticker[] }) => (
+interface StickersPageProps {
+  user: HeaderUser | null
+  stickers: StickerCardSticker[]
+}
+
+export function StickersPage(handle: Handle<StickersPageProps>) {
+  return () => {
+    const { user, stickers } = handle.props
+    return (
     <Document title="stickertrade - stickers" user={user}>
       <main>
         <p mix={heading}>stickers</p>
@@ -16,7 +23,8 @@ export function StickersPage() {
         </div>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const heading = css({

--- a/app/actions/surface-page.tsx
+++ b/app/actions/surface-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -24,8 +24,9 @@ export interface SurfacePageProps {
   canEdit: boolean
 }
 
-export function SurfacePage() {
-  return ({ user, surface, images, canEdit }: SurfacePageProps) => {
+export function SurfacePage(handle: Handle<SurfacePageProps>) {
+  return () => {
+    const { user, surface, images, canEdit } = handle.props
     const description = surface.description ?? `A sticker surface by ${surface.owner.username}.`
     const primaryImage = images[0]
     const galleryImages = images.slice(1)

--- a/app/actions/surfaces-page.tsx
+++ b/app/actions/surfaces-page.tsx
@@ -1,11 +1,18 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { SurfaceCard, type SurfaceCardSurface } from '../ui/surface-card.tsx'
 
-export function SurfacesPage() {
-  return ({ user, surfaces }: { user: HeaderUser | null; surfaces: SurfaceCardSurface[] }) => (
+interface SurfacesPageProps {
+  user: HeaderUser | null
+  surfaces: SurfaceCardSurface[]
+}
+
+export function SurfacesPage(handle: Handle<SurfacesPageProps>) {
+  return () => {
+    const { user, surfaces } = handle.props
+    return (
     <Document title="stickertrade - surfaces" user={user}>
       <main mix={mainStyle}>
         <p mix={heading}>surfaces</p>
@@ -20,7 +27,8 @@ export function SurfacesPage() {
         )}
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const mainStyle = css({ maxWidth: '40rem', margin: '0 auto' })

--- a/app/actions/upload-sticker-page.tsx
+++ b/app/actions/upload-sticker-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -11,8 +11,10 @@ export interface UploadStickerPageProps {
   values?: { name?: string }
 }
 
-export function UploadStickerPage() {
-  return ({ user, errors = {}, values = {} }: UploadStickerPageProps) => (
+export function UploadStickerPage(handle: Handle<UploadStickerPageProps>) {
+  return () => {
+    const { user, errors = {}, values = {} } = handle.props
+    return (
     <Document title="stickertrade - upload sticker" user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>upload sticker</h1>
@@ -33,7 +35,8 @@ export function UploadStickerPage() {
         </p>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const linkRowStyle = css({

--- a/app/actions/upload-surface-page.tsx
+++ b/app/actions/upload-surface-page.tsx
@@ -1,4 +1,4 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
@@ -25,8 +25,10 @@ const textareaExtraStyle = css({
   fontFamily: 'inherit',
 })
 
-export function UploadSurfacePage() {
-  return ({ user, errors = {}, values = {} }: UploadSurfacePageProps) => (
+export function UploadSurfacePage(handle: Handle<UploadSurfacePageProps>) {
+  return () => {
+    const { user, errors = {}, values = {} } = handle.props
+    return (
     <Document title="stickertrade - upload surface" user={user}>
       <main mix={css({ maxWidth: '32rem', margin: '0 auto' })}>
         <h1 mix={css({ fontSize: '1.5rem', marginBottom: '1rem' })}>upload surface</h1>
@@ -63,5 +65,6 @@ export function UploadSurfacePage() {
         </form>
       </main>
     </Document>
-  )
+    )
+  }
 }

--- a/app/actions/users-page.tsx
+++ b/app/actions/users-page.tsx
@@ -1,11 +1,18 @@
-import { css } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
 import { UserCard, type UserCardUser } from '../ui/user-card.tsx'
 
-export function UsersPage() {
-  return ({ user, users }: { user: HeaderUser | null; users: UserCardUser[] }) => (
+interface UsersPageProps {
+  user: HeaderUser | null
+  users: UserCardUser[]
+}
+
+export function UsersPage(handle: Handle<UsersPageProps>) {
+  return () => {
+    const { user, users } = handle.props
+    return (
     <Document title="stickertrade - users" user={user}>
       <main>
         <p mix={heading}>users</p>
@@ -16,7 +23,8 @@ export function UsersPage() {
         </div>
       </main>
     </Document>
-  )
+    )
+  }
 }
 
 const heading = css({

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -1,4 +1,4 @@
-import { css, type RemixNode } from 'remix/ui'
+import { css, type Handle, type RemixNode } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Footer } from './footer.tsx'
@@ -21,35 +21,38 @@ export interface DocumentProps {
 
 const DEFAULT_TITLE = 'stickertrade'
 
-export function Document() {
-  return ({
-    children,
-    head,
-    title = DEFAULT_TITLE,
-    user = null,
-    showChrome = true,
-    og,
-  }: DocumentProps) => (
-    <html lang="en" mix={css({ height: '100%' })}>
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <OgTags title={og?.title ?? title} {...og} />
-        <title>{title}</title>
-        {head}
-      </head>
-      <body mix={bodyStyle}>
-        <div mix={shellStyle}>
-          {showChrome ? <Header user={user} /> : null}
-          {showChrome ? <WipBanner /> : null}
-          <div mix={css({ paddingTop: '1.25rem', paddingBottom: '2rem' })}>{children}</div>
-        </div>
-        {showChrome ? <Footer /> : null}
-        <script type="module" src={routes.assets.href({ path: 'app/assets/entry.ts' })}></script>
-      </body>
-    </html>
-  )
+export function Document(handle: Handle<DocumentProps>) {
+  return () => {
+    const {
+      children,
+      head,
+      title = DEFAULT_TITLE,
+      user = null,
+      showChrome = true,
+      og,
+    } = handle.props
+    return (
+      <html lang="en" mix={css({ height: '100%' })}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+          <OgTags title={og?.title ?? title} {...og} />
+          <title>{title}</title>
+          {head}
+        </head>
+        <body mix={bodyStyle}>
+          <div mix={shellStyle}>
+            {showChrome ? <Header user={user} /> : null}
+            {showChrome ? <WipBanner /> : null}
+            <div mix={css({ paddingTop: '1.25rem', paddingBottom: '2rem' })}>{children}</div>
+          </div>
+          {showChrome ? <Footer /> : null}
+          <script type="module" src={routes.assets.href({ path: 'app/assets/entry.ts' })}></script>
+        </body>
+      </html>
+    )
+  }
 }
 
 const FONT_STACK =

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
         "bcryptjs": "^3.0.2",
         "feed": "^5.1.0",
         "front-matter": "^4.0.2",
-        "marked": "^14.1.3",
-        "remix": "^3.0.0-beta.2",
+        "marked": "^18.0.5",
+        "remix": "^3.0.0-beta.4",
         "sharp": "^0.34.2"
       },
       "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "^25.9.2",
         "typescript": "latest"
       },
       "engines": {
@@ -23,14 +23,14 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
-      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
+      "integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
       "cpu": [
         "arm"
       ],
@@ -1775,9 +1775,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-android-arm64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
-      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
+      "integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
       "cpu": [
         "arm64"
       ],
@@ -1788,9 +1788,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
-      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
+      "integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1801,9 +1801,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-x64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
-      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
+      "integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
       "cpu": [
         "x64"
       ],
@@ -1814,9 +1814,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
-      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
+      "integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
       "cpu": [
         "x64"
       ],
@@ -1827,9 +1827,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
-      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
+      "integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
       "cpu": [
         "arm"
       ],
@@ -1840,9 +1840,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
-      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
+      "integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
       "cpu": [
         "arm"
       ],
@@ -1853,9 +1853,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
-      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
+      "integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
       "cpu": [
         "arm64"
       ],
@@ -1869,9 +1869,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
-      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
+      "integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
       "cpu": [
         "arm64"
       ],
@@ -1885,9 +1885,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
-      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
+      "integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1901,9 +1901,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
-      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
+      "integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
       "cpu": [
         "riscv64"
       ],
@@ -1917,9 +1917,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
-      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
+      "integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
       "cpu": [
         "riscv64"
       ],
@@ -1933,9 +1933,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
-      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
+      "integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
       "cpu": [
         "s390x"
       ],
@@ -1949,9 +1949,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
-      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
+      "integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
       "cpu": [
         "x64"
       ],
@@ -1965,9 +1965,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
-      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
+      "integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
       "cpu": [
         "x64"
       ],
@@ -1981,9 +1981,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
-      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
+      "integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
       "cpu": [
         "arm64"
       ],
@@ -1994,25 +1994,48 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
-      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
+      "integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
-      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
+      "integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
       "cpu": [
         "arm64"
       ],
@@ -2022,23 +2045,10 @@
         "win32"
       ]
     },
-    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
-      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
-      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
+      "integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
       "cpu": [
         "x64"
       ],
@@ -2456,22 +2466,22 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/assert/-/assert-0.2.1.tgz",
-      "integrity": "sha512-jHoxChSCIbueiED3ZeMqWGNZMVYFN/7Eo51PkID174dPloRHeXLL7Kj9Ck1phtXPalEyofzWsxdWwKUnQYHzCw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/assert/-/assert-0.3.0.tgz",
+      "integrity": "sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ==",
       "license": "MIT"
     },
     "node_modules/@remix-run/assets": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/assets/-/assets-0.4.1.tgz",
-      "integrity": "sha512-Voz6sv+vHTm9hImF0uz1FsYMbWiSYJDKxljBD65LCqUmlVP6bwsXm/wkyybhx3OzpybczejuYQvJ07wA0lCYcg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/assets/-/assets-0.4.3.tgz",
+      "integrity": "sha512-3YKANQIc/dATxy9+7VpaILXZ4KPOP7y888EbyAphvEu++jOILpjHxMi5N+fhXoRZxpmL+CXaB7PKEwbsAAnKpA==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": "^0.121.0",
-        "@remix-run/file-storage": "0.13.5",
-        "@remix-run/headers": "0.21.0",
+        "@remix-run/file-storage": "0.13.6",
+        "@remix-run/headers": "0.21.1",
         "@remix-run/mime": "0.4.1",
-        "@remix-run/route-pattern": "0.21.1",
+        "@remix-run/route-pattern": "0.22.1",
         "chokidar": "^5.0.0",
         "es-module-lexer": "^2.0.0",
         "get-tsconfig": "^4.13.6",
@@ -2486,42 +2496,42 @@
       }
     },
     "node_modules/@remix-run/async-context-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/async-context-middleware/-/async-context-middleware-0.3.1.tgz",
-      "integrity": "sha512-B4l+t4PNITlZy2llDG/d5XmJ4dJP0Kstx3V62FIo76u2/IXqqRDt0X+FSZFQoRJeX58kKMl74Snok5MTqoddaA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/async-context-middleware/-/async-context-middleware-0.3.3.tgz",
+      "integrity": "sha512-Qg53vPttFVX9kxYjn8dxd+/BpCCe9gaYGPUze+YAMvQ73InKyeTF1a4zqnmHgHxTVp2qYK+kp0derTVlRAMTpQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1"
+        "@remix-run/fetch-router": "^0.20.0"
       }
     },
     "node_modules/@remix-run/auth": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/auth/-/auth-0.2.3.tgz",
-      "integrity": "sha512-AvnEo7Md5rYrDxItPnBLELJx8YRw1jmgpNJrWB7nK4xzIm5M8MSPRnPgkguxAUqe20+n2RKvxiE48IsEq5yLbg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/auth/-/auth-0.2.5.tgz",
+      "integrity": "sha512-liwLro3rHgtjTc3MuYD4iKlZUcVvAzZUSGk0Tc1JFd7QSI8E8G2QeCxJvZRpul6TO0ojnjSogNydmj42ZpI4iQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/session": "^0.4.2"
       }
     },
     "node_modules/@remix-run/auth-middleware": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/auth-middleware/-/auth-middleware-0.2.1.tgz",
-      "integrity": "sha512-NdoC3wUq7ofq4B1ouox6YYyJiLl1KoOC5lT1Sl6c1n/wH6+hEoxBby1pi3WveIO/WALgDXRoDfZp9GPUQEVh+A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/auth-middleware/-/auth-middleware-0.2.3.tgz",
+      "integrity": "sha512-dUt/b/Vj4dntpORbQ9bV51eWyi7DyHM7zV4EfbSGsw7jyYfwtRptqu5Y3gAW6YlGAM1jp+ahSUMSzOqb1EEKWw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/session": "^0.4.2"
       }
     },
     "node_modules/@remix-run/cli": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/cli/-/cli-0.3.1.tgz",
-      "integrity": "sha512-deoObBzsFNOwJj+Rj3DERNj3F8CEH/wXcfk5JqvQa7AR1CQpplok45JAX5znBffL18ikqJvCTdOYpD8XdRzeig==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/cli/-/cli-0.3.3.tgz",
+      "integrity": "sha512-3ho5CuzpIA6IIyY48EvAsA5I2c5mlT6RNvGa5/oSi6OutgNX+Fb9UDLIw7MbvKRvaIL6b/XOHT0LCQ+TrIAL+g==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/terminal": "^0.1.1",
-        "@remix-run/test": "^0.4.1",
+        "@remix-run/test": "^0.5.0",
         "semver": "^7.7.4"
       },
       "engines": {
@@ -2529,51 +2539,51 @@
       }
     },
     "node_modules/@remix-run/compression-middleware": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@remix-run/compression-middleware/-/compression-middleware-0.1.9.tgz",
-      "integrity": "sha512-F2Z+LDI4n6vBIk+oIwlUX1lc5oMMvZ9WEiLxnlyPkMvoPbh28dYFme62lAUQXIC8Y4lZ+NkLLdZZ3wioLLZ9SA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@remix-run/compression-middleware/-/compression-middleware-0.1.11.tgz",
+      "integrity": "sha512-VgnCV8cZqH11HhBXqIbgskUaK7ORkFlVBy9I+6dQQKWpDv/WnouFtKI2anlAfYqUZ+6WCfyBTNlq5FfbAz5lVA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/mime": "^0.4.1",
-        "@remix-run/response": "^0.3.5"
+        "@remix-run/response": "^0.3.6"
       }
     },
     "node_modules/@remix-run/cookie": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/cookie/-/cookie-0.5.3.tgz",
-      "integrity": "sha512-y5geVHe1yCE26yEkrRjJEYak9nYibQJVxoKvfEi5p6xvaH6p3Z6Q3GZ5UHmFkTl9sedXJ3uGjkaQW+cnPAWkZQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-QxV2yo0umBXxwMub8kZFC+nOFnGMVpGo3jQ1Gvs4p1n2N7/0LAKhPgKsWbsk5ab6EqVhpr0S+v9gSQON1nuyoA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/headers": "^0.21.0"
+        "@remix-run/headers": "^0.21.1"
       }
     },
     "node_modules/@remix-run/cop-middleware": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/cop-middleware/-/cop-middleware-0.1.4.tgz",
-      "integrity": "sha512-HqPRPzEfj/LqF8KO1af2539FQnS4WtbuZ5Uxxse7JveCARL0Lu5dNbZWc46l51vFc5VNvRVT2P1KiULyZn3ONg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/cop-middleware/-/cop-middleware-0.1.6.tgz",
+      "integrity": "sha512-KPTHCIunLQxzNHXPel0jYFpKcmM7TF9GxMaitV0NGh8JktRDX0ckS+6lpHk7gGf06lIBYcafgqwrIVdp/LXSXg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1"
+        "@remix-run/fetch-router": "^0.20.0"
       }
     },
     "node_modules/@remix-run/cors-middleware": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/cors-middleware/-/cors-middleware-0.1.4.tgz",
-      "integrity": "sha512-4l1jS8vx3EAzLhxPXp8bv1UVdWBoOJVBrV2/TqzTGGOjxhYRNLGImB/g1TD7fBsN4k2cen40lhFsqGLSZuHE9g==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/cors-middleware/-/cors-middleware-0.1.6.tgz",
+      "integrity": "sha512-n4+sL7ePUhtWKrTjSfjs37sgz228cZPQbSyOEPy6b8nGhX8cRDFYqkF3M9BSelxoP4sWfIQZTaE1LTGAemHrrA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
-        "@remix-run/headers": "^0.21.0"
+        "@remix-run/fetch-router": "^0.20.0",
+        "@remix-run/headers": "^0.21.1"
       }
     },
     "node_modules/@remix-run/csrf-middleware": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/csrf-middleware/-/csrf-middleware-0.1.4.tgz",
-      "integrity": "sha512-FuMf8lEqkb1ldydBCoP++aZ+iYKY/kgPqas5MRbiQ6M6yX18DUfvZfP2B9fq4s9b4n6fsb/rLYqEYkVYDVD3dA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/csrf-middleware/-/csrf-middleware-0.1.6.tgz",
+      "integrity": "sha512-qqF92bQFwKu3qnLvMjFPhf6B0gHr4U4ZolLFcfOVgK8OcszHZQdBCLwmwGu+G6MxbaNnk0OtE+kL36liJ5+Tzw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/session": "^0.4.2"
       }
     },
@@ -2627,85 +2637,85 @@
       }
     },
     "node_modules/@remix-run/data-table-sqlite": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/data-table-sqlite/-/data-table-sqlite-0.5.0.tgz",
-      "integrity": "sha512-B8jwMXq1ZVqMo0ZycYTRHjmOYK6drRo4s30IBvZ9VHpjDcNvyEx6/mXLKus+15C53Gnxf2KVh0cDkLi5jVEXyg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-table-sqlite/-/data-table-sqlite-0.5.1.tgz",
+      "integrity": "sha512-YgpUz49eeddYHOY3ebWi4Xeu94KWICRPrmsotkWpTIQdnf/sV+Ddx8BS4kUs+y9JJ/efrjAeHl/LNH6swpvM8g==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/data-table": "^0.3.0"
       }
     },
     "node_modules/@remix-run/fetch-proxy": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/fetch-proxy/-/fetch-proxy-0.8.2.tgz",
-      "integrity": "sha512-PtwhtKLogCjcF6fokd3BxwPLbZJK1ZgX0dG78Yg+9RzqgCu8UfvOuuNdUadi4eJEhNYr9+KFKyiWYdYxYjLetA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/fetch-proxy/-/fetch-proxy-0.8.3.tgz",
+      "integrity": "sha512-FP2/0DIdnPGXMk+UAsRhYmunj3ElH2QNjuvD7VjjyWOAs9vHn7XnvfKk+qs1VDXAO5J9fkzwPQ+Y0n9FJZ8srQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/headers": "^0.21.0"
+        "@remix-run/headers": "^0.21.1"
       }
     },
     "node_modules/@remix-run/fetch-router": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/fetch-router/-/fetch-router-0.19.1.tgz",
-      "integrity": "sha512-MsU7WidGOdorGJzEBgtqCFDto1AafCZou5n5jzA47Sjc9UB8y1FcAiUOZq6Kp6B9C4ghtDv4p1yEWyhka1Th3w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/fetch-router/-/fetch-router-0.20.0.tgz",
+      "integrity": "sha512-iNjDAesu37Yf8nApAkKgKjmZBavC+AuzWK9EUmiwo+OnH7nn8ag5whyVFR4kb0LJN5CeXciFEIjX+oHG5cNeyw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/route-pattern": "^0.21.1"
+        "@remix-run/route-pattern": "^0.22.1"
       }
     },
     "node_modules/@remix-run/file-storage": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/file-storage/-/file-storage-0.13.5.tgz",
-      "integrity": "sha512-xESA575OMf7F3TIxmmWrTkuj7CAgq9VKKXAhjHvvpQJmEUOXPE+yjEcG7TxbIe3gE+/KC1Hxbtqm9DHYyW/otg==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/file-storage/-/file-storage-0.13.6.tgz",
+      "integrity": "sha512-dXX7gcoPPWFa/041U/fCW9jHS11v8oC8UCrMRpbkyltz+tI55KvJ60oHYPUqnu75b9Ep60lZHvNviqlSn1Iv4w==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fs": "^0.4.4",
-        "@remix-run/lazy-file": "^5.0.4"
+        "@remix-run/fs": "^0.4.5",
+        "@remix-run/lazy-file": "^5.0.5"
       }
     },
     "node_modules/@remix-run/file-storage-s3": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/file-storage-s3/-/file-storage-s3-0.1.2.tgz",
-      "integrity": "sha512-HJEHEtXqjGk+uhQ1A97Wkzfg5RxmiQgyvQMiqZ2q6fGKPXgzWplnXmFegmKg3CjXPEENqBbsp+AKSnhj02BaUw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/file-storage-s3/-/file-storage-s3-0.1.3.tgz",
+      "integrity": "sha512-15OlGiiiSJnM4KlrcCxYBqIRHAubNEy8LsBRnI/bXXzsSgNOS/gnAi9dhjkgHScLPtgr8Xf0kyO1zUl82/41dA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/file-storage": "^0.13.5",
+        "@remix-run/file-storage": "^0.13.6",
         "aws4fetch": "^1.0.20"
       }
     },
     "node_modules/@remix-run/form-data-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/form-data-middleware/-/form-data-middleware-0.3.1.tgz",
-      "integrity": "sha512-toKu0bFcRvzr3u7kKM7nkpjPginGqgZ14dhenaG3SI7PQMk2/Zd8SK6w9Da3PN9F/JyEDTYrYIK74UYKYADLdg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/form-data-middleware/-/form-data-middleware-0.3.3.tgz",
+      "integrity": "sha512-46FpwGGyjJXvH1ZioZtL8FGO14qDASqaZmnqXmeUspZ4XvtEVAiEfzcPYUnmCNzrvBSuGlgU5WqUfOQxbtXAHA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
-        "@remix-run/form-data-parser": "^0.17.2"
+        "@remix-run/fetch-router": "^0.20.0",
+        "@remix-run/form-data-parser": "^0.17.3"
       }
     },
     "node_modules/@remix-run/form-data-parser": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/form-data-parser/-/form-data-parser-0.17.2.tgz",
-      "integrity": "sha512-6V9XffMkADkCHa/zLZQI2NVx1jDPiGtuiJ5cv9tmYzDn4KXjEJfqwHo6Fj8l95MThfoz5BTkkk2DOW2HEnuYkA==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/form-data-parser/-/form-data-parser-0.17.3.tgz",
+      "integrity": "sha512-K23ImS2P+Gl4ZEK00dEa2GAuhQJkxocvMsnF5SafcRh4aoKINUcdiCQraBDP+929c3VxnP3nUj5UYzBtGuGIIw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/multipart-parser": "^0.16.2"
+        "@remix-run/multipart-parser": "^0.16.3"
       }
     },
     "node_modules/@remix-run/fs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/fs/-/fs-0.4.4.tgz",
-      "integrity": "sha512-G+L/u6FOzcIOmjaJj+eLRSAXwokYb6LScUjjF56oxRebTORkYdM7OjdJFjay78DH56tBmY5DoWAC56s19M59RQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/fs/-/fs-0.4.5.tgz",
+      "integrity": "sha512-aruAQN2R//NQBeKg3YnovJ4JMZRmJ0pVWq3xoUMTeO16L6dCP82Al+dSizwGHy7ZavPfJwnlJHp5exTAhX5yCQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/lazy-file": "^5.0.4",
+        "@remix-run/lazy-file": "^5.0.5",
         "@remix-run/mime": "^0.4.1"
       }
     },
     "node_modules/@remix-run/headers": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/headers/-/headers-0.21.0.tgz",
-      "integrity": "sha512-jlVE0GGxTaLqZ8cfB/sBDQYkKHXJxhWlLY836A7kjnHmy2oHET8J3/4+7+JgTqFBEBvK+ZiiqJKZElj+/zp5Cg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/headers/-/headers-0.21.1.tgz",
+      "integrity": "sha512-DRhRveigepAQDUIi0MrOFhpcl3/KTv/fkpIhulv7Asv1pUwM8RpY2ENjdI8lfii6Z3MEsWtYhGt6If8bi6bYpQ==",
       "license": "MIT"
     },
     "node_modules/@remix-run/html-template": {
@@ -2715,31 +2725,31 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/lazy-file": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/lazy-file/-/lazy-file-5.0.4.tgz",
-      "integrity": "sha512-OwG3AIDYEHiuhqK6XstZk/IolhWlIxhrLNSMRxP5BVREHUl1c7RrzcbSHqXXGzNXZUa1+mER9kLf71tT/MgssA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/lazy-file/-/lazy-file-5.0.5.tgz",
+      "integrity": "sha512-PhjTgR266T2qDKki6lQnlOtgZv4VB8Dqeu1sBUu2pBazgi2nZA2n7lvDpNiegKozBgGfUXS8ScdIQ6FPuNvtcw==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/mime": "^0.4.1"
       }
     },
     "node_modules/@remix-run/logger-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/logger-middleware/-/logger-middleware-0.3.1.tgz",
-      "integrity": "sha512-150cdoHZ5SkQlrPbJXnKXgM1JSa8QS1/vEabDg/cYv20in2Wdm5egPmKhGcOK1jfgSY6DIcHCDtwEXPO81/qhg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/logger-middleware/-/logger-middleware-0.3.3.tgz",
+      "integrity": "sha512-nrKhWowr3PPimgwngx3U343ohS5noBTx1jgohMVP+3M0DxrQbJNppXu2qty93XZk4XGECj+DgQhU9U1O8ARLcA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/terminal": "^0.1.1"
       }
     },
     "node_modules/@remix-run/method-override-middleware": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@remix-run/method-override-middleware/-/method-override-middleware-0.1.9.tgz",
-      "integrity": "sha512-6qh0Hqjh42pqTXhs7vP/BwR0H5ifOY/+Oc5pqleNLTU7pMyI6Q5Q61F4u57tNiVp0N8+zz64nqIMUXF/DYaq1A==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@remix-run/method-override-middleware/-/method-override-middleware-0.1.11.tgz",
+      "integrity": "sha512-OP9yc33e3bEkjJ36YgVlUVuQcIUSLpFjjpDA7etK1qgRNE2EHBmVBR5ypqfGF2PORV0FnLvmAaeVpdz3eo/CNA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1"
+        "@remix-run/fetch-router": "^0.20.0"
       }
     },
     "node_modules/@remix-run/mime": {
@@ -2749,12 +2759,12 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/multipart-parser": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/multipart-parser/-/multipart-parser-0.16.2.tgz",
-      "integrity": "sha512-3B36kyAa/bKGzciNWFQM8MBQT291059Q6vjkqgmDPgENFfaejORIVKYpUHJGLHtTI62xrnLXxgL89kXE/nVzSQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/multipart-parser/-/multipart-parser-0.16.3.tgz",
+      "integrity": "sha512-XvMYPIyDTuquR7s1YF4wo4CqMPDrBkpWY0zHSa7SpX0F+t9awg7FWd5mJywc6vTn4oWeS7nQYQQarZ9CuoC/RQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/headers": "^0.21.0"
+        "@remix-run/headers": "^0.21.1"
       }
     },
     "node_modules/@remix-run/node-fetch-server": {
@@ -2777,29 +2787,29 @@
       }
     },
     "node_modules/@remix-run/render-middleware": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/render-middleware/-/render-middleware-0.1.1.tgz",
-      "integrity": "sha512-XjJ+g+0DnmNgova7yy2JKh4NUG90VbWle2eeWFU9d96dg45SOlVgaj9WwX6w8zBR2hdYIm+zvne1W+v/p24shQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/render-middleware/-/render-middleware-0.1.3.tgz",
+      "integrity": "sha512-wxrjRdYbiE7yT2VhCe1M7/ir4M44M6cxwnzCdxd8qVIg+i4lbFdizDR72ClDNoAQ2hPtlHDy7+2U+ufnNHUGRQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1"
+        "@remix-run/fetch-router": "^0.20.0"
       }
     },
     "node_modules/@remix-run/response": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/response/-/response-0.3.5.tgz",
-      "integrity": "sha512-oGttVnDgL8rNWA9ShGizYyAjJJiz+d1lcgtYeXiw9QiU9lGIliJ8b1KgPilMGKjALyf+SyePnb5SSG1DRYt9eg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/response/-/response-0.3.6.tgz",
+      "integrity": "sha512-WgbAXEGesrfVz449Lv1AUruT2r2t79XxkcG/cdzDZWXB/2UKcKFsVSM/tFvfmIuAtwdvhQrrnaFpnC04OfYSNA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/headers": "^0.21.0",
+        "@remix-run/headers": "^0.21.1",
         "@remix-run/html-template": "^0.3.1",
         "@remix-run/mime": "^0.4.1"
       }
     },
     "node_modules/@remix-run/route-pattern": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.21.1.tgz",
-      "integrity": "sha512-vXTyJPwicRY2PyNoT3l6Ql4EM4eenPyDOAQGxH4p/+jIDuX3312xxQe3BQ+fhdspobJtnKaEgTWVKBZb+9ArWQ==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.22.1.tgz",
+      "integrity": "sha512-czdGJWh09Lapvcqt7Vb09KlrU2PhRJ8xQaI+AItTuD9aDJ5MAgxnS38lnys6Ll+6RJEqPiaUqTwIQhVLwFvv+w==",
       "license": "MIT"
     },
     "node_modules/@remix-run/session": {
@@ -2809,20 +2819,20 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/session-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/session-middleware/-/session-middleware-0.3.1.tgz",
-      "integrity": "sha512-IgOMdeOT2/Xt1g3E1YMvwmqhckVjvr6c5Jz59T/pEwM4Vqoq9xMzQ8xrgzngtBiqkaFQ4Hh/OcD6pRjpRWBaXA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/session-middleware/-/session-middleware-0.3.3.tgz",
+      "integrity": "sha512-mMY3DJNpRAdEu6TMAVV0N6kGr3UCvucfunHHOzvWwMy7QVXqIgYFfJFIzWuHiKKGVUdNyBhDAADA3e9eLNtXRA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/cookie": "^0.5.3",
-        "@remix-run/fetch-router": "^0.19.1",
+        "@remix-run/cookie": "^0.5.4",
+        "@remix-run/fetch-router": "^0.20.0",
         "@remix-run/session": "^0.4.2"
       }
     },
     "node_modules/@remix-run/session-storage-memcache": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/session-storage-memcache/-/session-storage-memcache-0.1.1.tgz",
-      "integrity": "sha512-s8LTKot70DBK4J2FEGLmFyzlPkM3bgk34E7m4Cz4SVwlqigXkQcZuaWr+hgX5TynaezGU6775HNtx0eoTCT9Vw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/session-storage-memcache/-/session-storage-memcache-0.1.2.tgz",
+      "integrity": "sha512-VIJnz+DcJFo+vM1SRKy/8kbJHefVQtGyKS+V1AOMCk8OAMGCCyS+f4ERxmu3as48T/L55oBPsTxQX+rcPchDtQ==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/session": "^0.4.2"
@@ -2846,16 +2856,16 @@
       }
     },
     "node_modules/@remix-run/static-middleware": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@remix-run/static-middleware/-/static-middleware-0.4.10.tgz",
-      "integrity": "sha512-wloJGCiyuIQ/teGNHKwIyWZB54PEU68G89Fm31gTczig6P03SSe8eZzOlbJHirMpNWfHsqtLEGbOgCzyrkdc9Q==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@remix-run/static-middleware/-/static-middleware-0.4.12.tgz",
+      "integrity": "sha512-ovppEYU9SdEzt7+jIZYN+ReD4LaWau2Vi98obAzgMdOfKBiP3C0ftdXhVmTBBtDq0kJdFoVi7NE/c95FpnGkwg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/fetch-router": "^0.19.1",
-        "@remix-run/fs": "^0.4.4",
+        "@remix-run/fetch-router": "^0.20.0",
+        "@remix-run/fs": "^0.4.5",
         "@remix-run/html-template": "^0.3.1",
         "@remix-run/mime": "^0.4.1",
-        "@remix-run/response": "^0.3.5"
+        "@remix-run/response": "^0.3.6"
       }
     },
     "node_modules/@remix-run/tar-parser": {
@@ -2871,9 +2881,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/test": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/test/-/test-0.4.1.tgz",
-      "integrity": "sha512-5PzhLa1/B+TEgTJ46xJ0ytWUxDZjnkw40VbsXt82qta4GlrRFsoUif8kBfXWNyAyfdHWTBn+4/PqMeev5DYMRA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/test/-/test-0.5.0.tgz",
+      "integrity": "sha512-jaJLJi7+YXFh4JblWe3hjqve8tkiZ1Nzsog1j6EwCEv814bHldCqBbFrajI69DUULd3nNCs3Mk3rz96lt83xYA==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/node-tsx": "^0.1.1",
@@ -2885,6 +2895,7 @@
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
         "magic-string": "^0.30.21",
+        "oxc-resolver": "^11.19.1",
         "source-map-js": "^1.2.1",
         "v8-to-istanbul": "^9.3.0"
       },
@@ -2895,7 +2906,7 @@
         "node": ">=24.3.0"
       },
       "peerDependencies": {
-        "playwright": "^1.59.0"
+        "playwright": "^1.60.0"
       },
       "peerDependenciesMeta": {
         "playwright": {
@@ -2904,9 +2915,9 @@
       }
     },
     "node_modules/@remix-run/ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/ui/-/ui-0.2.0.tgz",
-      "integrity": "sha512-KSqtZGRZVgGjX3uEsdBuIHElWcgVi6HS6QnIMrpAcuh/fDxceGwNyKaskujtTU4BQmm+PClYyVfkeNx2l+BaCg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/ui/-/ui-0.3.0.tgz",
+      "integrity": "sha512-5zWmsnrls7UPioYg5vRNK3YQam5O3GGZBPONgi50f1Si3QPIdjNQvOEN2Qj1TcY3ehtLcsGgtBbba6AsXRR85A==",
       "license": "MIT",
       "dependencies": {
         "@types/dom-navigation": "^1.0.7"
@@ -2941,9 +2952,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3620,15 +3631,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
-      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {
@@ -3767,34 +3778,33 @@
       }
     },
     "node_modules/oxc-resolver": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
-      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
+      "integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
-        "@oxc-resolver/binding-android-arm64": "11.19.1",
-        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
-        "@oxc-resolver/binding-darwin-x64": "11.19.1",
-        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
-        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
-        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
-        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
-        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
-        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
-        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
-        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
-        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
-        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
-        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+        "@oxc-resolver/binding-android-arm-eabi": "11.20.0",
+        "@oxc-resolver/binding-android-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-x64": "11.20.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.20.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.20.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.20.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
       }
     },
     "node_modules/oxc-transform": {
@@ -3887,55 +3897,55 @@
       }
     },
     "node_modules/remix": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-3.0.0-beta.2.tgz",
-      "integrity": "sha512-wrsKdoKyQrumhm2tlmjhZC+5GzZkYE/LHRd07dSgKZW1M0uQQ+wj3Qq45AOTHT5JmXXFrVU3Vs6RpyKZaFGXwg==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/remix/-/remix-3.0.0-beta.4.tgz",
+      "integrity": "sha512-KT3elI5Xqbsuy17EXyAicM4aOrbReMMu4ozwRVGxe+XYu7IiZ0q4ScCHUg2MLRrazADLewbZLIODrK61LGMfwg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/assert": "^0.2.1",
-        "@remix-run/assets": "^0.4.1",
-        "@remix-run/async-context-middleware": "^0.3.1",
-        "@remix-run/auth": "^0.2.3",
-        "@remix-run/auth-middleware": "^0.2.1",
-        "@remix-run/cli": "^0.3.1",
-        "@remix-run/compression-middleware": "^0.1.9",
-        "@remix-run/cookie": "^0.5.3",
-        "@remix-run/cop-middleware": "^0.1.4",
-        "@remix-run/cors-middleware": "^0.1.4",
-        "@remix-run/csrf-middleware": "^0.1.4",
+        "@remix-run/assert": "^0.3.0",
+        "@remix-run/assets": "^0.4.3",
+        "@remix-run/async-context-middleware": "^0.3.3",
+        "@remix-run/auth": "^0.2.5",
+        "@remix-run/auth-middleware": "^0.2.3",
+        "@remix-run/cli": "^0.3.3",
+        "@remix-run/compression-middleware": "^0.1.11",
+        "@remix-run/cookie": "^0.5.4",
+        "@remix-run/cop-middleware": "^0.1.6",
+        "@remix-run/cors-middleware": "^0.1.6",
+        "@remix-run/csrf-middleware": "^0.1.6",
         "@remix-run/data-schema": "^0.3.0",
         "@remix-run/data-table": "^0.3.0",
         "@remix-run/data-table-mysql": "^0.4.0",
         "@remix-run/data-table-postgres": "^0.4.0",
-        "@remix-run/data-table-sqlite": "^0.5.0",
-        "@remix-run/fetch-proxy": "^0.8.2",
-        "@remix-run/fetch-router": "^0.19.1",
-        "@remix-run/file-storage": "^0.13.5",
-        "@remix-run/file-storage-s3": "^0.1.2",
-        "@remix-run/form-data-middleware": "^0.3.1",
-        "@remix-run/form-data-parser": "^0.17.2",
-        "@remix-run/fs": "^0.4.4",
-        "@remix-run/headers": "^0.21.0",
+        "@remix-run/data-table-sqlite": "^0.5.1",
+        "@remix-run/fetch-proxy": "^0.8.3",
+        "@remix-run/fetch-router": "^0.20.0",
+        "@remix-run/file-storage": "^0.13.6",
+        "@remix-run/file-storage-s3": "^0.1.3",
+        "@remix-run/form-data-middleware": "^0.3.3",
+        "@remix-run/form-data-parser": "^0.17.3",
+        "@remix-run/fs": "^0.4.5",
+        "@remix-run/headers": "^0.21.1",
         "@remix-run/html-template": "^0.3.1",
-        "@remix-run/lazy-file": "^5.0.4",
-        "@remix-run/logger-middleware": "^0.3.1",
-        "@remix-run/method-override-middleware": "^0.1.9",
+        "@remix-run/lazy-file": "^5.0.5",
+        "@remix-run/logger-middleware": "^0.3.3",
+        "@remix-run/method-override-middleware": "^0.1.11",
         "@remix-run/mime": "^0.4.1",
-        "@remix-run/multipart-parser": "^0.16.2",
+        "@remix-run/multipart-parser": "^0.16.3",
         "@remix-run/node-fetch-server": "^0.13.3",
         "@remix-run/node-tsx": "^0.1.1",
-        "@remix-run/render-middleware": "^0.1.1",
-        "@remix-run/response": "^0.3.5",
-        "@remix-run/route-pattern": "^0.21.1",
+        "@remix-run/render-middleware": "^0.1.3",
+        "@remix-run/response": "^0.3.6",
+        "@remix-run/route-pattern": "^0.22.1",
         "@remix-run/session": "^0.4.2",
-        "@remix-run/session-middleware": "^0.3.1",
-        "@remix-run/session-storage-memcache": "^0.1.1",
+        "@remix-run/session-middleware": "^0.3.3",
+        "@remix-run/session-storage-memcache": "^0.1.2",
         "@remix-run/session-storage-redis": "^0.1.1",
-        "@remix-run/static-middleware": "^0.4.10",
+        "@remix-run/static-middleware": "^0.4.12",
         "@remix-run/tar-parser": "^0.7.1",
         "@remix-run/terminal": "^0.1.1",
-        "@remix-run/test": "^0.4.1",
-        "@remix-run/ui": "^0.2.0"
+        "@remix-run/test": "^0.5.0",
+        "@remix-run/ui": "^0.3.0"
       },
       "bin": {
         "remix": "dist/cli-entry.js"
@@ -3946,7 +3956,7 @@
       "peerDependencies": {
         "mysql2": "^3.15.3",
         "pg": "^8.16.3",
-        "playwright": "^1.59.0",
+        "playwright": "^1.60.0",
         "redis": "^5.10.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "bcryptjs": "^3.0.2",
     "feed": "^5.1.0",
     "front-matter": "^4.0.2",
-    "marked": "^14.1.3",
-    "remix": "^3.0.0-beta.2",
+    "marked": "^18.0.5",
+    "remix": "^3.0.0-beta.4",
     "sharp": "^0.34.2"
   },
   "devDependencies": {
-    "@types/node": "latest",
+    "@types/node": "^25.9.2",
     "typescript": "latest"
   }
 }


### PR DESCRIPTION
## Summary

Routine dependency refresh. `npm audit` reports **0 vulnerabilities** before and after — no CVEs hitting us. The headline change is the remix bump, which pulled in `@remix-run/ui@0.3.0` with a breaking component-model change. That cascaded into a 24-file mechanical refactor.

## Bumps

| Package | From | To | Notes |
|---|---|---|---|
| `remix` | 3.0.0-beta.2 | 3.0.0-beta.4 | Breaking change in `@remix-run/ui@0.3.0`; middleware tightening in beta.4 (no-op for us — every middleware already returns `next()`). |
| `marked` | 14.1.4 | 18.0.5 | Four majors. v16 drops CJS (we're ESM); v17 changes list token shape (we don't read AST); v18 trims trailing blank lines (cosmetic). Our usage is just `marked.parse(s, { async: false })`. |
| `@types/node` | 25.9.1 | 25.9.2 | Patch. Also pinned the spec from `"latest"` to `"^25.9.2"` to avoid silent drift on re-install. |

## The @remix-run/ui@0.3.0 breaking change

From their release notes:

> BREAKING CHANGE: Remix UI component render functions no longer receive props as an argument. Type component props on `Handle<Props>` and read current values from `handle.props` in both setup and render code.

### Before
```tsx
export function FooPage() {
  return ({ user, errors = {} }: FooPageProps) => (
    <Document title="..." user={user}>...</Document>
  )
}
```

### After
```tsx
export function FooPage(handle: Handle<FooPageProps>) {
  return () => {
    const { user, errors = {} } = handle.props
    return (
      <Document title="..." user={user}>...</Document>
    )
  }
}
```

Refactored all 24 page components plus `Document`. `app/ui/form.tsx` sub-components and everything under `app/assets/batch-upload-stickers/` were already on the new pattern, so they didn't need changes.

## Verification

- `npm audit` → 0 vulnerabilities
- `npm run typecheck` → clean
- `npm test` → 117/117 passing
- Smoke-checked `/` and `/login` via curl against the dev server — both 200, full HTML renders (header, footer, WIP banner, stickers grid, CSRF token in the login form).

## What's NOT in this PR

- The `@huggingface/transformers` dep is already at 4.2.0 and stays pinned there; the batch upload feature's importmap targets `@4.2.0` and bumping needs coordination.
- `sharp`, `bcryptjs`, `feed`, `front-matter` had no updates to install.
- The pre-existing `front-matter` 'unused?' depcheck warning is a false positive — `app/data/dev-logs.ts` uses it via a dynamic `require_('front-matter')` call.