### PR TITLE
brand: site-wide audit, swap off-brand hex for theme tokens

### DIFF
--- a/app/actions/batch-upload-stickers-page.tsx
+++ b/app/actions/batch-upload-stickers-page.tsx
@@ -6,6 +6,7 @@ import { BatchUploadStickersApp } from '../assets/batch-upload-stickers/controll
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import type { HeaderUser } from '../ui/header.tsx'
+import { colors } from '../ui/theme.ts'
 
 export interface BatchUploadStickersPageProps {
   user: HeaderUser
@@ -103,16 +104,17 @@ const blurbStyle = css({
   opacity: 0.8,
 })
 
-// Theme colors inlined as hex on this page because we use them here directly;
-// the rest of the feature lives under app/assets/ which can't reach theme.ts.
+// The `secondary` (mustard) token plays the "heads up / experimental" role
+// in the palette — see /brand. Same gentle border + tinted-background
+// pattern as before, just on-brand.
 const experimentalTagStyle = css({
   display: 'inline-block',
   marginLeft: '0.5rem',
   padding: '0.125rem 0.5rem',
   fontSize: '0.75rem',
   fontWeight: 'normal',
-  background: '#f59e0b',
-  color: '#1c0f13',
+  background: colors.secondary[500],
+  color: colors.dark[500],
   borderRadius: '0.25rem',
   verticalAlign: 'middle',
   textTransform: 'uppercase',
@@ -120,8 +122,8 @@ const experimentalTagStyle = css({
 })
 
 const noticeStyle = css({
-  border: '1px solid #f59e0b66',
-  background: '#f59e0b14',
+  border: `1px solid ${colors.secondary[500]}66`,
+  background: `${colors.secondary[500]}14`,
   borderRadius: '0.5rem',
   padding: '0.75rem 1rem',
   marginBottom: '1.5rem',
@@ -132,7 +134,7 @@ const noticeHeadingStyle = css({
   margin: 0,
   marginBottom: '0.5rem',
   fontWeight: 'bold',
-  color: '#f59e0b',
+  color: colors.secondary[500],
 })
 
 const noticeListStyle = css({

--- a/app/actions/dev-log-page.tsx
+++ b/app/actions/dev-log-page.tsx
@@ -45,12 +45,12 @@ const markdownStyle = css({
   '& ul, & ol': { paddingLeft: '1.25rem', margin: '0.5rem 0' },
   '& li': { margin: '0.25rem 0' },
   '& code': {
-    background: '#0e0709',
+    background: colors.dark[400],
     padding: '0.1rem 0.3rem',
     fontSize: '0.9em',
   },
   '& pre': {
-    background: '#0e0709',
+    background: colors.dark[400],
     padding: '0.75rem',
     overflow: 'auto',
   },

--- a/app/actions/edit-profile-page.tsx
+++ b/app/actions/edit-profile-page.tsx
@@ -250,7 +250,7 @@ const tokenRowStyle = css({
 const newTokenBoxStyle = css({
   marginBottom: '1rem',
   padding: '0.75rem',
-  background: '#0e0709',
+  background: colors.dark[400],
   border: `1px solid ${colors.primary[500]}`,
 })
 

--- a/app/actions/edit-sticker-page.tsx
+++ b/app/actions/edit-sticker-page.tsx
@@ -64,7 +64,7 @@ export function EditStickerPage(handle: Handle<EditStickerPageProps>) {
 const previewStyle = css({
   maxWidth: '100%',
   border: `2px solid ${colors.light[500]}40`,
-  background: '#000',
+  background: colors.dark[600],
 })
 
 const cancelLinkStyle = css({

--- a/app/actions/edit-surface-page.tsx
+++ b/app/actions/edit-surface-page.tsx
@@ -165,7 +165,7 @@ const galleryImgStyle = css({
   maxHeight: '22rem',
   objectFit: 'contain',
   display: 'block',
-  background: '#000',
+  background: colors.dark[600],
 })
 
 const galleryActionsStyle = css({

--- a/app/actions/sticker-page.tsx
+++ b/app/actions/sticker-page.tsx
@@ -65,7 +65,7 @@ export function StickerPage(handle: Handle<StickerPageProps>) {
 const imageWrapStyle = css({
   width: '100%',
   border: `2px solid ${colors.light[500]}40`,
-  background: '#000',
+  background: colors.dark[600],
 })
 
 const imageStyle = css({

--- a/app/actions/surface-page.tsx
+++ b/app/actions/surface-page.tsx
@@ -97,7 +97,7 @@ export function SurfacePage(handle: Handle<SurfacePageProps>) {
 const imageWrapStyle = css({
   width: '100%',
   border: `2px solid ${colors.light[500]}40`,
-  background: '#000',
+  background: colors.dark[600],
 })
 
 const imageStyle = css({

--- a/app/assets/batch-upload-stickers/canvas.ts
+++ b/app/assets/batch-upload-stickers/canvas.ts
@@ -7,10 +7,19 @@ import type { Region } from './types.ts'
  * component owns event registration.
  *
  * Theme colors inlined (asset server's allow list excludes `app/ui/theme.ts`).
- * Hex values match `light.500` and `primary.500` tokens. Match `app/ui/theme.ts`.
+ * Hex values mirror `light.500`, `primary.500`, and `dark.500` tokens.
+ * Match `app/ui/theme.ts` and keep `stage-{transparency,finalize}.tsx`'s
+ * checker tiles in sync with `CHECKER_DARK` / `CHECKER_LIGHT` below.
  */
 const LIGHT_500 = '#f1eee4'
 const PRIMARY_500 = '#f7a1c4'
+const DARK_500 = '#1c0f13'
+
+// Brand-tinted checkerboard tile pair. `CHECKER_DARK` sits one notch
+// brighter than dark.500 to read as the "behind transparent" backdrop,
+// `CHECKER_LIGHT` is the alternating square.
+const CHECKER_DARK = '#1a1115'
+const CHECKER_LIGHT = '#241a1f'
 
 /** Minimum bbox dimension in image-space pixels (mirrors the Python tool). */
 const MIN_REGION_DIM = 12
@@ -359,9 +368,9 @@ export function draw(ctx: CanvasRenderingContext2D, state: CanvasState): void {
 
 function drawCheckerboard(ctx: CanvasRenderingContext2D, w: number, h: number): void {
   const size = 12
-  ctx.fillStyle = '#1a1115'
+  ctx.fillStyle = CHECKER_DARK
   ctx.fillRect(0, 0, w, h)
-  ctx.fillStyle = '#241a1f'
+  ctx.fillStyle = CHECKER_LIGHT
   for (let y = 0; y < h; y += size) {
     for (let x = ((y / size) % 2) * size; x < w; x += size * 2) {
       ctx.fillRect(x, y, size, size)
@@ -371,8 +380,11 @@ function drawCheckerboard(ctx: CanvasRenderingContext2D, w: number, h: number): 
 
 function drawHandle(ctx: CanvasRenderingContext2D, cx: number, cy: number): void {
   const half = HANDLE_DRAW_PX / 2
+  // `#ffffff` is functional (max-contrast handle fill against any image),
+  // not a brand color. Handle outline matches body bg so it tucks visually
+  // into the surrounding canvas.
   ctx.fillStyle = '#ffffff'
-  ctx.strokeStyle = '#1d2430'
+  ctx.strokeStyle = DARK_500
   ctx.lineWidth = 1
   ctx.fillRect(cx - half, cy - half, HANDLE_DRAW_PX, HANDLE_DRAW_PX)
   ctx.strokeRect(cx - half, cy - half, HANDLE_DRAW_PX, HANDLE_DRAW_PX)

--- a/app/assets/batch-upload-stickers/stage-finalize.tsx
+++ b/app/assets/batch-upload-stickers/stage-finalize.tsx
@@ -8,11 +8,15 @@ import type { TransparencyResult } from './transparency.ts'
 const LIGHT_500 = '#f1eee4'
 const PRIMARY_500 = '#f7a1c4'
 const DARK_500 = '#1c0f13'
-const SUCCESS = '#4ade80'
-const DANGER = '#ef4444'
+// SUCCESS / DANGER mirror the `success.500` / `danger.500` tokens on
+// /brand. Inlined here because the asset server can't import theme.ts.
+const SUCCESS = '#a8c69b'
+const DANGER = '#c75d5d'
 
-const CHECKER_LIGHT = '#222'
-const CHECKER_DARK = '#1a1a1a'
+// Brand-tinted checkerboard (mirrors canvas.ts so the transparent-image
+// backdrop reads the same across the canvas and the css-rendered preview).
+const CHECKER_LIGHT = '#241a1f'
+const CHECKER_DARK = '#1a1115'
 const CHECKER_SIZE = '12px'
 
 export interface StageFinalizeItem {

--- a/app/assets/batch-upload-stickers/stage-review.tsx
+++ b/app/assets/batch-upload-stickers/stage-review.tsx
@@ -7,6 +7,7 @@ import type { Region } from './types.ts'
 // outside the `app/ui/theme.ts` allow list).
 const LIGHT_500 = '#f1eee4'
 const PRIMARY_500 = '#f7a1c4'
+const DARK_400 = '#0e0709'
 const DARK_500 = '#1c0f13'
 
 export interface StageReviewProps {
@@ -352,7 +353,7 @@ const canvasWrapStyle = css({
   // page container's max-width. Switch to flex-1 once the page lives inside
   // a true viewport-height shell.
   height: 'min(70vh, 700px)',
-  background: '#0e0709',
+  background: DARK_400,
   border: `1px solid ${LIGHT_500}33`,
   borderRadius: '0.25rem',
   overflow: 'hidden',

--- a/app/assets/batch-upload-stickers/stage-transparency.tsx
+++ b/app/assets/batch-upload-stickers/stage-transparency.tsx
@@ -8,7 +8,9 @@ import type { TransparencyResult } from './transparency.ts'
 const LIGHT_500 = '#f1eee4'
 const PRIMARY_500 = '#f7a1c4'
 const DARK_500 = '#1c0f13'
-const DANGER = '#ef4444'
+// DANGER mirrors the `danger.500` token on /brand. Inlined here because
+// the asset server can't import theme.ts.
+const DANGER = '#c75d5d'
 
 export type RegionDecision = 'keep' | 'skip'
 
@@ -485,8 +487,9 @@ const tileRowStyle = css({
   gap: '0.5rem',
 })
 
-const CHECKER_LIGHT = '#222'
-const CHECKER_DARK = '#1a1a1a'
+// Brand-tinted checkerboard, matches canvas.ts and stage-finalize.tsx.
+const CHECKER_LIGHT = '#241a1f'
+const CHECKER_DARK = '#1a1115'
 const CHECKER_SIZE = '12px'
 
 // Checkerboard backdrop: two diagonal gradients offset by half a tile. The

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -86,7 +86,7 @@ function WipBanner() {
     <div mix={css({ display: 'flex', flexDirection: 'column', alignItems: 'center' })}>
       <p
         mix={css({
-          background: '#ef4444',
+          background: colors.danger[500],
           color: colors.dark[500],
           fontSize: '1.25rem',
           margin: '2rem 0.5rem 0',

--- a/app/ui/form.tsx
+++ b/app/ui/form.tsx
@@ -99,7 +99,7 @@ export const fieldStyle = css({ display: 'block', marginBottom: '0.75rem' })
 export const inputStyle = css({
   width: '100%',
   padding: '0.5rem 0.75rem',
-  background: '#0e0709',
+  background: colors.dark[400],
   color: colors.light[500],
   border: `1px solid ${colors.light[500]}55`,
   font: 'inherit',
@@ -133,7 +133,7 @@ export const helperTextStyle = css({
 export const flashStyle = css({
   marginBottom: '0.75rem',
   padding: '0.5rem 0.75rem',
-  background: '#0e0709',
+  background: colors.dark[400],
   border: `1px solid ${colors.primary[500]}`,
   color: colors.primary[500],
 })

--- a/app/ui/sticker-card.tsx
+++ b/app/ui/sticker-card.tsx
@@ -67,14 +67,14 @@ const cardStyle = css({
   width: '12rem',
   padding: '0.5rem',
   border: `2px solid ${colors.light[500]}40`,
-  background: '#0e0709',
+  background: colors.dark[400],
   '&:hover': { borderColor: colors.primary[500] },
 })
 
 const imageWrapStyle = css({
   width: '100%',
   aspectRatio: '1 / 1',
-  background: '#000',
+  background: colors.dark[600],
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/app/ui/surface-card.tsx
+++ b/app/ui/surface-card.tsx
@@ -81,7 +81,7 @@ const cardStyle = css({
   marginBottom: '2rem',
   padding: '0.5rem',
   border: `2px solid ${colors.light[500]}40`,
-  background: '#0e0709',
+  background: colors.dark[400],
   textDecoration: 'none',
   color: 'inherit',
   '&:hover': { borderColor: colors.primary[500] },
@@ -110,7 +110,7 @@ const uploadIconStyle = css({
 
 const imageWrapStyle = css({
   width: '100%',
-  background: '#000',
+  background: colors.dark[600],
 })
 
 const imageStyle = css({

--- a/app/ui/theme.ts
+++ b/app/ui/theme.ts
@@ -1,5 +1,16 @@
 // Shared design tokens carried over from the v1 Tailwind palette.
 // https://coolors.co/f1eee4-1c0f13-f7a1c4-f5d491-1985a1
+//
+// Token semantics:
+//   primary    pink — accents, hover, highlights
+//   secondary  mustard — warn / experimental / heads-up
+//   dark.400   deep — card surfaces sitting one notch below body bg
+//   dark.500   the body background; ink on light surfaces
+//   dark.600   image wells (pure black, behind transparent images)
+//   light      cream — body text and subtle UI
+//   success    sage — confirmation tints; harmonised with secondary
+//   danger     brick — warnings/errors; tuned to sit next to the other
+//              accents instead of a vibrant alarm-red
 
 export const colors = {
   primary: {
@@ -10,12 +21,20 @@ export const colors = {
     500: '#f5d491',
   },
   dark: {
+    400: '#0e0709',
     500: '#1c0f13',
+    600: '#000000',
   },
   light: {
     500: '#f1eee4',
     600: '#d8d6cd',
     700: '#c0beb6',
+  },
+  success: {
+    500: '#a8c69b',
+  },
+  danger: {
+    500: '#c75d5d',
   },
 } as const
 


### PR DESCRIPTION
## Why

The experimental notice on `/upload-sticker/batch` used amber (`#f59e0b`) that doesn't appear anywhere on `/brand`. Expanded that into a full site-wide audit: every inline hex code checked against the brand palette.

## Audit findings (4 categories)

1. **Brand mirrors** in `app/assets/**` — already aligned (LIGHT_500/PRIMARY_500/DARK_500 inlined because the asset server's allow list doesn't include `app/ui/theme.ts`). No changes.
2. **"Darker than dark" backgrounds** (`#0e0709`, `#000`) — used in ~10 files for two semantically distinct roles (card surface vs image well). Named: `dark.400` and `dark.600`.
3. **Off-brand status colors**:
   - `#f59e0b` amber — the user's complaint, batch upload experimental notice. → `secondary.500` (mustard).
   - `#ef4444` red — WIP banner + DANGER constants. → new `danger.500` (brick).
   - `#4ade80` green — SUCCESS constant in batch finalize. → new `success.500` (sage).
4. **Inconsistent canvas checkerboards** across 3 files (`#222`/`#1a1a1a` vs `#1a1115`/`#241a1f`) — standardized on the brand-tinted pair.

## New tokens in `app/ui/theme.ts`

| Token | Hex | Role |
|---|---|---|
| `dark.400` | `#0e0709` | deep card surfaces |
| `dark.600` | `#000000` | image wells |
| `success.500` | `#a8c69b` | sage — confirmation tints |
| `danger.500` | `#c75d5d` | brick — warnings/errors |

Sage + brick chosen to harmonize with the existing pink/mustard/cream palette rather than the previous bootstrap-style vibrant green/red. They sit next to `secondary` (mustard) without clashing.

`/brand` iterates `Object.entries(colors)` so the new tokens render automatically as swatches — verified via curl.

## Files modified
16 files, +75/-34. Notable:
- `app/ui/theme.ts` (+19/-0) — tokens + doc comment
- `app/ui/document.tsx` — WIP banner red → `danger.500` (kept the loud caps voice per the brand-page guidance)
- `app/actions/batch-upload-stickers-page.tsx` — the user's amber complaint, all 4 instances → `secondary.500`
- `app/ui/{sticker-card,surface-card,form}.tsx` + 6 action pages — dark.400/.600
- `app/assets/batch-upload-stickers/{canvas,stage-review,stage-finalize,stage-transparency}` — brand mirrors for DARK_400/SUCCESS/DANGER, unified checker tile pair

## Verification

```
/brand                       200  renders all 11 tokens (4 new swatches visible)
/upload-sticker/batch        200  off-brand counts: f59e0b=0, ef4444=0
                                  on-brand: f5d491=4, c75d5d=1 (wip banner)
npm run typecheck            clean
npm test                     117/117 pass
```

## What's deliberately NOT changed

- WIP banner voice (`WARNING:` caps + loud background) — only the red hex changed
- Two `#ffffff`s in `canvas.ts` — functional white for selection contrast and handle fill, not brand-relevant (comment added)
- `FONT_STACK` — out of scope for a color audit
- Brand mirrors in `copy-button.tsx` / batch-upload `controller.tsx` — already aligned

## Resolution of the user's specific concern

Before: `/upload-sticker/batch` used 4 instances of `#f59e0b` (off-brand amber) for the experimental tag and notice.
After: 0 instances of `#f59e0b`, 4 instances of `secondary.500` (`#f5d491` — mustard, on `/brand`). Same gentle border + tinted-background pattern, just on-brand.